### PR TITLE
Add logstash to the adm group on ubuntu

### DIFF
--- a/site-cookbooks/bb_external/recipes/logstash_agent.rb
+++ b/site-cookbooks/bb_external/recipes/logstash_agent.rb
@@ -4,6 +4,12 @@
   end
 end
 
+# Add the logstash user to the adm group so they can get the logs
+group "adm" do
+  action :modify
+  members "logstash"
+  append true
+end
 
 file_inputs = []
 


### PR DESCRIPTION
nginx logs are owned by www-data:adm as installed by the nginx cookbook, so logstash needs to join that group to read them