### PR TITLE
Updated several pieces while deploying the internal opsviz stack

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -1,1944 +1,1900 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "",
-    "Mappings": {
-        "AWSNATAMI": {
-            "ap-northeast-1": {
-                "AMI": "ami-14d86d15"
-            },
-            "ap-southeast-1": {
-                "AMI": "ami-02eb9350"
-            },
-            "eu-west-1": {
-                "AMI": "ami-0b5b6c7f"
-            },
-            "sa-east-1": {
-                "AMI": "ami-0439e619"
-            },
-            "us-east-1": {
-                "AMI": "ami-c6699baf"
-            },
-            "us-west-1": {
-                "AMI": "ami-3bcc9e7e"
-            },
-            "us-west-2": {
-                "AMI": "ami-52ff7262"
-            }
-        },
-        "SubnetConfig": {
-            "Private": {
-                "CIDR": "10.133.1.0/24"
-            },
-            "Public": {
-                "CIDR": "10.133.0.0/24"
-            },
-            "VPC": {
-                "CIDR": "10.133.0.0/16"
-            }
-        }
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "",
+  "Parameters": {
+    "CookbooksRepo": {
+      "Description": "The github url for your custom cookbooks",
+      "Type": "String"
     },
-    "Outputs": {
-        "DashboardUrl": {
-            "Value": {
-                "Fn::GetAtt": [
-                    "DashboardELB",
-                    "DNSName"
-                ]
-            }
-        },
-        "PrivateSubnet": {
-            "Value": {
-                "Ref": "PrivateSubnet"
-            }
-        },
-        "PublicSubnet": {
-            "Value": {
-                "Ref": "PublicSubnet"
-            }
-        },
-        "StackId": {
-            "Value": {
-                "Ref": "OpsWorksStack"
-            }
-        },
-        "VPC": {
-            "Description": "VPC",
-            "Value": {
-                "Ref": "VPC"
-            }
-        }
+    "CookbooksRef": {
+      "Description": "The git reference to checkout for custom cookbooks",
+      "Type": "String",
+      "Default": "master"
     },
-    "Parameters": {
-        "BastionInstanceType": {
-            "AllowedValues": [
-                "t2.small",
-                "t2.medium",
-                "m3.medium"
-            ],
-            "Default": "m3.medium",
-            "Description": "Enter t2.small, t2.medium, m3.medium. Default is t2.small.",
-            "Type": "String"
-        },
-        "CookbooksRef": {
-            "Default": "master",
-            "Description": "The git reference to checkout for custom cookbooks",
-            "Type": "String"
-        },
-        "CookbooksRepo": {
-            "Description": "The github url for your custom cookbooks",
-            "Type": "String"
-        },
-        "CookbooksSshKey": {
-            "Default": "",
-            "Description": "The ssh key needed to clone the cookbooks repo",
-            "NoEcho": "true",
-            "Type": "String"
-        },
-        "DashboardInstanceType": {
-            "AllowedValues": [
-                "m3.medium",
-                "m3.large",
-                "c3.large",
-                "r3.large",
-                "m3.2xlarge"
-            ],
-            "Default": "c3.large",
-            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large.",
-            "Type": "String"
-        },
-        "DoormanEnable": {
-            "AllowedValues": [
-                "true",
-                "false"
-            ],
-            "Default": "true",
-            "Description": "Protect all internal resources through Doorman? If you are not deploying this privately through a VPN, this is recommended",
-            "Type": "String"
-        },
-        "DoormanPassword": {
-            "Default": "",
-            "Description": "Password to use for alternate authentication through doorman. Leave empty for none",
-            "Type": "String"
-        },
-        "DoormanSessionSecret": {
-            "Default": "",
-            "Description": "A Secret Salt used to encrypt cookies for doorman",
-            "NoEcho": "true",
-            "Type": "String"
-        },
-        "ElasticSearchInstanceType": {
-            "AllowedValues": [
-                "m3.medium",
-                "m3.large",
-                "c3.large",
-                "r3.large"
-            ],
-            "Default": "r3.large",
-            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is r3.large.",
-            "Type": "String"
-        },
-        "ElasticSearchVolumeSize": {
-            "Default": 1000,
-            "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
-            "MinValue": 20,
-            "Type": "Number"
-        },
-        "GithubOauthAppId": {
-            "Default": "",
-            "Description": "Github Oauth App Id to use for doorman authentication. Leave empty for none.",
-            "Type": "String"
-        },
-        "GithubOauthOrganization": {
-            "Default": "",
-            "Description": "Github Organization to allow through doorman",
-            "Type": "String"
-        },
-        "GithubOauthSecret": {
-            "Default": "",
-            "Description": "Github Oauth App Secret to use for doorman authentication. Leave empty for none.",
-            "NoEcho": "true",
-            "Type": "String"
-        },
-        "GraphiteInstanceType": {
-            "AllowedValues": [
-                "m3.medium",
-                "m3.large",
-                "c3.large",
-                "r3.large"
-            ],
-            "Default": "c3.large",
-            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large.",
-            "Type": "String"
-        },
-        "GraphiteVolumeSize": {
-            "Default": 100,
-            "Description": "Size of disk in GB to use for graphite ebs volumes",
-            "MinValue": 20,
-            "Type": "Number"
-        },
-        "LogstashInstanceType": {
-            "AllowedValues": [
-                "m3.medium",
-                "m3.large",
-                "c3.large",
-                "r3.large"
-            ],
-            "Default": "c3.large",
-            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large.",
-            "Type": "String"
-        },
-        "OpsWorksStackColor": {
-            "Default": "rgb(45, 114, 184)",
-            "Description": "RGB Color to use for OpsWorks Stack",
-            "Type": "String"
-        },
-        "PagerDutyAPIKey": {
-            "Default": "",
-            "Description": "The pagerduty api key if you want sensu alerts forwarded to pagerduty",
-            "Type": "String"
-        },
-        "RabbitMQCertificateARN": {
-            "Description": "ARN of hte certificate to use for rabbitmq",
-            "Type": "String"
-        },
-        "RabbitMQErlangCookie": {
-            "Description": "RabbitMQ Erlang Cookie. This should be unique per stack",
-            "NoEcho": "true",
-            "Type": "String"
-        },
-        "RabbitMQInstanceType": {
-            "AllowedValues": [
-                "m3.large",
-                "c3.large",
-                "r3.large"
-            ],
-            "Default": "r3.large",
-            "Description": "Enter m3.large, c3.large, or r3.large. Default is r3.large.",
-            "Type": "String"
-        },
-        "RabbitMQLogstashExternalPassword": {
-            "Description": "RabbitMQ Password",
-            "Type": "String"
-        },
-        "RabbitMQLogstashExternalUser": {
-            "Default": "logstash_external",
-            "Description": "RabbitMQ User",
-            "Type": "String"
-        },
-        "RabbitMQLogstashInternalPassword": {
-            "Description": "RabbitMQ Password",
-            "Type": "String"
-        },
-        "RabbitMQLogstashInternalUser": {
-            "Default": "logstash_internal",
-            "Description": "RabbitMQ User",
-            "Type": "String"
-        },
-        "RabbitMQPassword": {
-            "Default": "hunter2",
-            "Description": "RabbitMQ Password",
-            "Type": "String"
-        },
-        "RabbitMQSensuPassword": {
-            "Description": "RabbitMQ Sensu Password",
-            "Type": "String"
-        },
-        "RabbitMQStatsdPassword": {
-            "Description": "RabbitMQ Statsd Password",
-            "Type": "String"
-        },
-        "RabbitMQUser": {
-            "Default": "logger",
-            "Description": "RabbitMQ User",
-            "Type": "String"
-        },
-        "RabbitMQVolumeSize": {
-            "Default": 20,
-            "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
-            "MinValue": 20,
-            "Type": "Number"
-        },
-        "Route53DomainName": {
-            "Default": "",
-            "Description": "The domain name to append to dns records",
-            "Type": "String"
-        },
-        "Route53ZoneId": {
-            "Default": "",
-            "Description": "The zone id to add dns records to on instance setup. If empty updates won't happen",
-            "Type": "String"
-        },
-        "Version": {
-            "Default": "0.1",
-            "Description": "Just a place holder for version",
-            "Type": "String"
-        }
+    "CookbooksSshKey": {
+      "Description": "The ssh key needed to clone the cookbooks repo",
+      "Type": "String",
+      "NoEcho": "true",
+      "Default": ""
     },
-    "Resources": {
-        "BastionInstance1": {
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "BastionInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksBastionLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "DashboardELB": {
-            "Properties": {
-                "HealthCheck": {
-                    "HealthyThreshold": "3",
-                    "Interval": "90",
-                    "Target": "HTTP:80/",
-                    "Timeout": "60",
-                    "UnhealthyThreshold": "5"
-                },
-                "Listeners": [
-                    {
-                        "InstancePort": "80",
-                        "LoadBalancerPort": "80",
-                        "Protocol": "HTTP"
-                    },
-                    {
-                        "InstancePort": "6379",
-                        "LoadBalancerPort": "6379",
-                        "Protocol": "TCP"
-                    },
-                    {
-                        "InstancePort": "4567",
-                        "LoadBalancerPort": "4567",
-                        "Protocol": "TCP"
-                    }
-                ],
-                "SecurityGroups": [
-                    {
-                        "Ref": "DashboardELBSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "Subnets": [
-                    {
-                        "Ref": "PublicSubnet"
-                    }
-                ]
-            },
-            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
-        },
-        "DashboardELBAttachment": {
-            "Properties": {
-                "ElasticLoadBalancerName": {
-                    "Ref": "DashboardELB"
-                },
-                "LayerId": {
-                    "Ref": "OpsWorksDashboardLayer"
-                }
-            },
-            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
-        },
-        "DashboardELBSecurityGroup": {
-            "Properties": {
-                "GroupDescription": "Allow inbound access to the ELB",
-                "SecurityGroupEgress": [
-                    {
-                        "CidrIp": "0.0.0.0/0",
-                        "FromPort": "80",
-                        "IpProtocol": "tcp",
-                        "ToPort": "80"
-                    }
-                ],
-                "SecurityGroupIngress": [
-                    {
-                        "CidrIp": "0.0.0.0/0",
-                        "FromPort": "80",
-                        "IpProtocol": "tcp",
-                        "ToPort": "80"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::SecurityGroup"
-        },
-        "DashboardInstance1": {
-            "DependsOn": [
-                "RabbitMQInstance1",
-                "GraphiteInstance1"
-            ],
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "DashboardInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksDashboardLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "ElasticSearchELB": {
-            "Properties": {
-                "HealthCheck": {
-                    "HealthyThreshold": "3",
-                    "Interval": "90",
-                    "Target": "TCP:9200",
-                    "Timeout": "60",
-                    "UnhealthyThreshold": "5"
-                },
-                "Listeners": [
-                    {
-                        "InstancePort": "9200",
-                        "LoadBalancerPort": "9200",
-                        "Protocol": "TCP"
-                    },
-                    {
-                        "InstancePort": "9300",
-                        "LoadBalancerPort": "9300",
-                        "Protocol": "TCP"
-                    }
-                ],
-                "Scheme": "internal",
-                "SecurityGroups": [
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "Subnets": [
-                    {
-                        "Ref": "PrivateSubnet"
-                    }
-                ]
-            },
-            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
-        },
-        "ElasticSearchELBAttachment": {
-            "Properties": {
-                "ElasticLoadBalancerName": {
-                    "Ref": "ElasticSearchELB"
-                },
-                "LayerId": {
-                    "Ref": "OpsWorksElasticSearchLayer"
-                }
-            },
-            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
-        },
-        "ElasticSearchInstance1": {
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "ElasticSearchInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksElasticSearchLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "ElasticSearchInstance2": {
-            "DependsOn": [
-                "ElasticSearchInstance1"
-            ],
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "ElasticSearchInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksElasticSearchLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "ElasticSearchInstance3": {
-            "DependsOn": [
-                "ElasticSearchInstance2"
-            ],
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "ElasticSearchInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksElasticSearchLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "GraphiteELB": {
-            "Properties": {
-                "HealthCheck": {
-                    "HealthyThreshold": "3",
-                    "Interval": "90",
-                    "Target": "TCP:2003",
-                    "Timeout": "60",
-                    "UnhealthyThreshold": "5"
-                },
-                "Listeners": [
-                    {
-                        "InstancePort": "8081",
-                        "LoadBalancerPort": "8081",
-                        "Protocol": "TCP"
-                    },
-                    {
-                        "InstancePort": "2003",
-                        "LoadBalancerPort": "2003",
-                        "Protocol": "TCP"
-                    }
-                ],
-                "Scheme": "internal",
-                "SecurityGroups": [
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "Subnets": [
-                    {
-                        "Ref": "PrivateSubnet"
-                    }
-                ]
-            },
-            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
-        },
-        "GraphiteELBAttachment": {
-            "Properties": {
-                "ElasticLoadBalancerName": {
-                    "Ref": "GraphiteELB"
-                },
-                "LayerId": {
-                    "Ref": "OpsWorksGraphiteLayer"
-                }
-            },
-            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
-        },
-        "GraphiteInstance1": {
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "GraphiteInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksGraphiteLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "InboundEmphemeralPublicNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PublicNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "1024",
-                    "To": "65535"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "103"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "InboundHTTPPublicNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PublicNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "80",
-                    "To": "80"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "InboundHTTPSPublicNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PublicNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "443",
-                    "To": "443"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "101"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "InboundPrivateNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PrivateNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "0",
-                    "To": "65535"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "InboundSSHPublicNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "false",
-                "NetworkAclId": {
-                    "Ref": "PublicNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "22",
-                    "To": "22"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "102"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "InternalSecurityGroup": {
-            "Properties": {
-                "GroupDescription": "Allow VPC access to ports running on dashboard server",
-                "SecurityGroupEgress": [
-                    {
-                        "CidrIp": "0.0.0.0/0",
-                        "FromPort": "0",
-                        "IpProtocol": "tcp",
-                        "ToPort": "65535"
-                    }
-                ],
-                "SecurityGroupIngress": [
-                    {
-                        "CidrIp": {
-                            "Fn::FindInMap": [
-                                "SubnetConfig",
-                                "VPC",
-                                "CIDR"
-                            ]
-                        },
-                        "FromPort": "0",
-                        "IpProtocol": "tcp",
-                        "ToPort": "65535"
-                    },
-                    {
-                        "FromPort": "0",
-                        "IpProtocol": "tcp",
-                        "SourceSecurityGroupId": {
-                            "Ref": "DashboardELBSecurityGroup"
-                        },
-                        "ToPort": "65535"
-                    },
-                    {
-                        "CidrIp": {
-                            "Fn::Join": [
-                                "",
-                                [
-                                    {
-                                        "Ref": "NATIPAddress"
-                                    },
-                                    "/32"
-                                ]
-                            ]
-                        },
-                        "FromPort": "0",
-                        "IpProtocol": "tcp",
-                        "ToPort": "65535"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::SecurityGroup"
-        },
-        "InternetGateway": {
-            "Properties": {
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ]
-            },
-            "Type": "AWS::EC2::InternetGateway"
-        },
-        "LogstashInstance1": {
-            "DependsOn": [
-                "ElasticSearchInstance1",
-                "ElasticSearchInstance2",
-                "ElasticSearchInstance3",
-                "RabbitMQInstance1"
-            ],
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "LogstashInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksLogstashLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "NATDevice": {
-            "Properties": {
-                "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSNATAMI",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        "AMI"
-                    ]
-                },
-                "InstanceType": "m1.small",
-                "SecurityGroupIds": [
-                    {
-                        "Ref": "NATSecurityGroup"
-                    }
-                ],
-                "SourceDestCheck": "false",
-                "SubnetId": {
-                    "Ref": "PublicSubnet"
-                }
-            },
-            "Type": "AWS::EC2::Instance"
-        },
-        "NATIPAddress": {
-            "Properties": {
-                "Domain": "vpc",
-                "InstanceId": {
-                    "Ref": "NATDevice"
-                }
-            },
-            "Type": "AWS::EC2::EIP"
-        },
-        "NATSecurityGroup": {
-            "Properties": {
-                "GroupDescription": "Allow OpsWorks instances to access the NAT Device",
-                "SecurityGroupEgress": [
-                    {
-                        "CidrIp": "0.0.0.0/0",
-                        "FromPort": "0",
-                        "IpProtocol": "tcp",
-                        "ToPort": "65535"
-                    }
-                ],
-                "SecurityGroupIngress": [
-                    {
-                        "FromPort": "80",
-                        "IpProtocol": "tcp",
-                        "SourceSecurityGroupId": {
-                            "Ref": "OpsWorksSecurityGroup"
-                        },
-                        "ToPort": "80"
-                    },
-                    {
-                        "FromPort": "9418",
-                        "IpProtocol": "tcp",
-                        "SourceSecurityGroupId": {
-                            "Ref": "OpsWorksSecurityGroup"
-                        },
-                        "ToPort": "9418"
-                    },
-                    {
-                        "FromPort": "443",
-                        "IpProtocol": "tcp",
-                        "SourceSecurityGroupId": {
-                            "Ref": "OpsWorksSecurityGroup"
-                        },
-                        "ToPort": "443"
-                    },
-                    {
-                        "CidrIp": {
-                            "Fn::FindInMap": [
-                                "SubnetConfig",
-                                "VPC",
-                                "CIDR"
-                            ]
-                        },
-                        "FromPort": "0",
-                        "IpProtocol": "tcp",
-                        "ToPort": "65535"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::SecurityGroup"
-        },
-        "OpsWorksBastionLayer": {
-            "DependsOn": [
-                "NATIPAddress",
-                "PublicRoute",
-                "PublicSubnetRouteTableAssociation",
-                "PrivateRoute",
-                "PrivateSubnetRouteTableAssociation"
-            ],
-            "Metadata": {
-                "Comment": "Put the bastion layer inside of opsworks so the same users that have access to opsworks will have access to bastion."
-            },
-            "Properties": {
-                "AutoAssignElasticIps": "true",
-                "AutoAssignPublicIps": "false",
-                "CustomRecipes": {
-                    "Configure": [
-                        "bb_monitor::sensu_client"
-                    ],
-                    "Deploy": [],
-                    "Setup": [
-                        "bb_monitor::route53",
-                        "bb_monitor::logstash_agent"
-                    ],
-                    "Shutdown": [],
-                    "Undeploy": []
-                },
-                "CustomSecurityGroupIds": [
-                    {
-                        "Ref": "OpsWorksSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "EnableAutoHealing": "true",
-                "Name": "Bastion",
-                "Shortname": "bastion",
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "Type": "custom"
-            },
-            "Type": "AWS::OpsWorks::Layer"
-        },
-        "OpsWorksDashboardLayer": {
-            "DependsOn": [
-                "NATIPAddress",
-                "PublicRoute",
-                "PublicSubnetRouteTableAssociation",
-                "PrivateRoute",
-                "PrivateSubnetRouteTableAssociation"
-            ],
-            "Metadata": {
-                "Comment": ""
-            },
-            "Properties": {
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "false",
-                "CustomRecipes": {
-                    "Configure": [
-                        "bb_monitor::sensu_client"
-                    ],
-                    "Deploy": [],
-                    "Setup": [
-                        "bb_monitor::kibana",
-                        "bb_monitor::grafana",
-                        "bb_monitor::sensu_server",
-                        "bb_monitor::nginx",
-                        "bb_monitor::route53",
-                        "bb_monitor::logstash_agent"
-                    ],
-                    "Shutdown": [],
-                    "Undeploy": []
-                },
-                "CustomSecurityGroupIds": [
-                    {
-                        "Ref": "OpsWorksSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "EnableAutoHealing": "true",
-                "Name": "Dashboard",
-                "Shortname": "dashboard",
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "Type": "custom"
-            },
-            "Type": "AWS::OpsWorks::Layer"
-        },
-        "OpsWorksElasticSearchLayer": {
-            "DependsOn": [
-                "NATIPAddress",
-                "PublicRoute",
-                "PublicSubnetRouteTableAssociation",
-                "PrivateRoute",
-                "PrivateSubnetRouteTableAssociation"
-            ],
-            "Metadata": {
-                "Comment": ""
-            },
-            "Properties": {
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "false",
-                "CustomRecipes": {
-                    "Configure": [
-                        "bb_monitor::sensu_client"
-                    ],
-                    "Deploy": [],
-                    "Setup": [
-                        "bb_elasticsearch",
-                        "bb_monitor::route53",
-                        "bb_monitor::logstash_agent"
-                    ],
-                    "Shutdown": [
-                        "bb_monitor::sensu_client_remove"
-                    ],
-                    "Undeploy": []
-                },
-                "CustomSecurityGroupIds": [
-                    {
-                        "Ref": "OpsWorksSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "EnableAutoHealing": "true",
-                "Name": "ElasticSearch",
-                "Shortname": "elasticsearch",
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "Type": "custom",
-                "VolumeConfigurations": [
-                    {
-                        "MountPoint": "/usr/local/var",
-                        "NumberOfDisks": 1,
-                        "Size": {
-                            "Ref": "ElasticSearchVolumeSize"
-                        }
-                    }
-                ]
-            },
-            "Type": "AWS::OpsWorks::Layer"
-        },
-        "OpsWorksGraphiteLayer": {
-            "DependsOn": [
-                "NATIPAddress",
-                "PublicRoute",
-                "PublicSubnetRouteTableAssociation",
-                "PrivateRoute",
-                "PrivateSubnetRouteTableAssociation"
-            ],
-            "Metadata": {
-                "Comment": ""
-            },
-            "Properties": {
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "false",
-                "CustomRecipes": {
-                    "Configure": [
-                        "bb_monitor::sensu_client"
-                    ],
-                    "Deploy": [],
-                    "Setup": [
-                        "bb_monitor::graphite",
-                        "bb_monitor::route53",
-                        "bb_monitor::logstash_agent"
-                    ],
-                    "Shutdown": [
-                        "bb_monitor::sensu_client_remove"
-                    ],
-                    "Undeploy": []
-                },
-                "CustomSecurityGroupIds": [
-                    {
-                        "Ref": "OpsWorksSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "EnableAutoHealing": "true",
-                "Name": "Graphite",
-                "Shortname": "graphite",
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "Type": "custom",
-                "VolumeConfigurations": [
-                    {
-                        "MountPoint": "/opt/graphite/storage",
-                        "NumberOfDisks": 1,
-                        "Size": {
-                            "Ref": "GraphiteVolumeSize"
-                        }
-                    }
-                ]
-            },
-            "Type": "AWS::OpsWorks::Layer"
-        },
-        "OpsWorksInstanceProfile": {
-            "Properties": {
-                "Path": "/",
-                "Roles": [
-                    {
-                        "Ref": "OpsWorksInstanceRole"
-                    }
-                ]
-            },
-            "Type": "AWS::IAM::InstanceProfile"
-        },
-        "OpsWorksInstanceRole": {
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ],
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": [
-                                    "ec2.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "Path": "/",
-                "Policies": [
-                    {
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "ec2:CreateSnapshot",
-                                        "ec2:CreateTags",
-                                        "ec2:DeleteSnapshot",
-                                        "ec2:Describe*"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": [
-                                        "*"
-                                    ]
-                                }
-                            ]
-                        },
-                        "PolicyName": "opsworks-instance-ec2"
-                    },
-                    {
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "opsworks:*",
-                                        "ec2:DescribeKeyPairs",
-                                        "ec2:DescribeSecurityGroups",
-                                        "ec2:DescribeAccountAttributes",
-                                        "ec2:DescribeAvailabilityZones",
-                                        "ec2:DescribeSecurityGroups",
-                                        "ec2:DescribeSubnets",
-                                        "ec2:DescribeVpcs",
-                                        "elasticloadbalancing:DescribeInstanceHealth",
-                                        "elasticloadbalancing:DescribeLoadBalancers",
-                                        "iam:GetRolePolicy",
-                                        "iam:ListInstanceProfiles",
-                                        "iam:ListRoles",
-                                        "iam:ListUsers",
-                                        "iam:PassRole"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": "*"
-                                }
-                            ]
-                        },
-                        "PolicyName": "opsworks-opsworks"
-                    },
-                    {
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "route53:*"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": [
-                                        "*"
-                                    ]
-                                }
-                            ]
-                        },
-                        "PolicyName": "opsworks-route53"
-                    },
-                    {
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "autoscaling:Describe*",
-                                        "cloudwatch:Describe*",
-                                        "cloudwatch:Get*",
-                                        "cloudwatch:List*",
-                                        "logs:Get*",
-                                        "logs:Describe*",
-                                        "logs:TestMetricFilter",
-                                        "sns:Get*",
-                                        "sns:List*"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": "*"
-                                }
-                            ]
-                        },
-                        "PolicyName": "opsworks-instance-cloudwatch"
-                    },
-                    {
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "elasticloadbalancing:DescribeInstanceHealth",
-                                        "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                                        "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
-                                        "elasticloadbalancing:DescribeLoadBalancerPolicies",
-                                        "elasticloadbalancing:DescribeLoadBalancers",
-                                        "elasticloadbalancing:DescribeTags"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": [
-                                        "*"
-                                    ]
-                                }
-                            ]
-                        },
-                        "PolicyName": "opsworks-instance-elb"
-                    }
-                ]
-            },
-            "Type": "AWS::IAM::Role"
-        },
-        "OpsWorksLogstashLayer": {
-            "DependsOn": [
-                "NATIPAddress",
-                "PublicRoute",
-                "PublicSubnetRouteTableAssociation",
-                "PrivateRoute",
-                "PrivateSubnetRouteTableAssociation"
-            ],
-            "Metadata": {
-                "Comment": ""
-            },
-            "Properties": {
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "false",
-                "CustomRecipes": {
-                    "Configure": [
-                        "bb_monitor::sensu_client"
-                    ],
-                    "Deploy": [],
-                    "Setup": [
-                        "bb_monitor::route53",
-                        "bb_monitor::logstash_server"
-                    ],
-                    "Shutdown": [
-                        "bb_monitor::sensu_client_remove"
-                    ],
-                    "Undeploy": []
-                },
-                "CustomSecurityGroupIds": [
-                    {
-                        "Ref": "OpsWorksSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "EnableAutoHealing": "true",
-                "Name": "Logstash",
-                "Shortname": "logstash",
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "Type": "custom"
-            },
-            "Type": "AWS::OpsWorks::Layer"
-        },
-        "OpsWorksRabbitMQLayer": {
-            "DependsOn": [
-                "NATIPAddress",
-                "PublicRoute",
-                "PublicSubnetRouteTableAssociation",
-                "PrivateRoute",
-                "PrivateSubnetRouteTableAssociation"
-            ],
-            "Metadata": {
-                "Comment": ""
-            },
-            "Properties": {
-                "AutoAssignElasticIps": "false",
-                "AutoAssignPublicIps": "false",
-                "CustomRecipes": {
-                    "Configure": [
-                        "bb_monitor::sensu_client"
-                    ],
-                    "Deploy": [],
-                    "Setup": [
-                        "rabbitmq_cluster",
-                        "bb_monitor::route53",
-                        "bb_monitor::logstash_agent"
-                    ],
-                    "Shutdown": [
-                        "bb_monitor::sensu_client_remove"
-                    ],
-                    "Undeploy": []
-                },
-                "CustomSecurityGroupIds": [
-                    {
-                        "Ref": "OpsWorksSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "EnableAutoHealing": "true",
-                "Name": "RabbitMQ",
-                "Shortname": "rabbitmq",
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                },
-                "Type": "custom",
-                "VolumeConfigurations": [
-                    {
-                        "MountPoint": "/var/lib/rabbitmq",
-                        "NumberOfDisks": 1,
-                        "Size": {
-                            "Ref": "RabbitMQVolumeSize"
-                        }
-                    }
-                ]
-            },
-            "Type": "AWS::OpsWorks::Layer"
-        },
-        "OpsWorksSecurityGroup": {
-            "Properties": {
-                "GroupDescription": "Allow inbound requests from the ELB to the OpsWorks instances",
-                "SecurityGroupIngress": [
-                    {
-                        "FromPort": "80",
-                        "IpProtocol": "tcp",
-                        "SourceSecurityGroupId": {
-                            "Ref": "DashboardELBSecurityGroup"
-                        },
-                        "ToPort": "80"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::SecurityGroup"
-        },
-        "OpsWorksServiceRole": {
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [
-                        {
-                            "Action": [
-                                "sts:AssumeRole"
-                            ],
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": [
-                                    "opsworks.amazonaws.com"
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "Path": "/",
-                "Policies": [
-                    {
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "ec2:*",
-                                        "iam:PassRole",
-                                        "cloudwatch:GetMetricStatistics",
-                                        "elasticloadbalancing:*"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": "*"
-                                }
-                            ]
-                        },
-                        "PolicyName": "opsworks-service"
-                    }
-                ]
-            },
-            "Type": "AWS::IAM::Role"
-        },
-        "OpsWorksStack": {
-            "Properties": {
-                "Attributes": {
-                    "Color": {
-                        "Ref": "OpsWorksStackColor"
-                    }
-                },
-                "ChefConfiguration": {
-                    "BerkshelfVersion": "3.1.3",
-                    "ManageBerkshelf": true
-                },
-                "ConfigurationManager": {
-                    "Name": "Chef",
-                    "Version": "11.10"
-                },
-                "CustomCookbooksSource": {
-                    "Revision": {
-                        "Ref": "CookbooksRef"
-                    },
-                    "SshKey": {
-                        "Ref": "CookbooksSshKey"
-                    },
-                    "Type": "git",
-                    "Url": {
-                        "Ref": "CookbooksRepo"
-                    }
-                },
-                "CustomJson": {
-                    "aws_region": {
-                        "Ref": "AWS::Region"
-                    },
-                    "bb_monitor": {
-                        "logstash": {
-                            "rabbitmq": {
-                                "password": {
-                                    "Ref": "RabbitMQLogstashInternalPassword"
-                                },
-                                "server": {
-                                    "Fn::GetAtt": [
-                                        "RabbitMQELB",
-                                        "DNSName"
-                                    ]
-                                }
-                            },
-                            "server": {
-                                "elasticsearch_server": {
-                                    "Fn::GetAtt": [
-                                        "ElasticSearchELB",
-                                        "DNSName"
-                                    ]
-                                },
-                                "filters": [],
-                                "statsd_output": {}
-                            }
-                        },
-                        "sensu": {
-                            "pagerduty_api": {
-                                "Ref": "PagerDutyAPIKey"
-                            },
-                            "rabbitmq": {
-                                "password": {
-                                    "Ref": "RabbitMQSensuPassword"
-                                },
-                                "server": {
-                                    "Fn::GetAtt": [
-                                        "RabbitMQELB",
-                                        "DNSName"
-                                    ]
-                                }
-                            },
-                            "server_url": {
-                                "Fn::GetAtt": [
-                                    "DashboardELB",
-                                    "DNSName"
-                                ]
-                            }
-                        }
-                    },
-                    "chef_environment": "production",
-                    "doorman": {
-                        "app_id": {
-                            "Ref": "GithubOauthAppId"
-                        },
-                        "app_secret": {
-                            "Ref": "GithubOauthSecret"
-                        },
-                        "org_name": {
-                            "Ref": "GithubOauthOrganization"
-                        },
-                        "password": {
-                            "Ref": "DoormanPassword"
-                        },
-                        "session_secret": {
-                            "Ref": "DoormanSessionSecret"
-                        }
-                    },
-                    "elasticsearch": {
-                        "cloud": {
-                            "aws": {
-                                "region": {
-                                    "Ref": "AWS::Region"
-                                }
-                            }
-                        },
-                        "cluster": {
-                            "name": "logstash"
-                        },
-                        "discovery": {
-                            "type": "ec2"
-                        },
-                        "http_auth": false,
-                        "index.auto_expand_replicas": "2-all",
-                        "index.number_of_replicas": 2,
-                        "index.number_of_shards": 8,
-                        "plugins": {
-                            "elasticsearch/elasticsearch-cloud-aws": {
-                                "version": "2.2.0"
-                            }
-                        },
-                        "version": "1.0.1"
-                    },
-                    "graphite": {
-                        "host": {
-                            "Fn::GetAtt": [
-                                "GraphiteELB",
-                                "DNSName"
-                            ]
-                        }
-                    },
-                    "kibana": {
-                        "elasticsearch_server": {
-                            "Fn::GetAtt": [
-                                "ElasticSearchELB",
-                                "DNSName"
-                            ]
-                        },
-                        "kibana3_version": "3.1.1",
-                        "version": "3"
-                    },
-                    "rabbitmq": {
-                        "cluster": true,
-                        "erlang_cookie": {
-                            "Ref": "RabbitMQErlangCookie"
-                        }
-                    },
-                    "rabbitmq_cluster": {
-                        "users": [
-                            {
-                                "password": {
-                                    "Ref": "RabbitMQPassword"
-                                },
-                                "user": {
-                                    "Ref": "RabbitMQUser"
-                                }
-                            },
-                            {
-                                "password": {
-                                    "Ref": "RabbitMQLogstashExternalPassword"
-                                },
-                                "user": {
-                                    "Ref": "RabbitMQLogstashExternalUser"
-                                }
-                            },
-                            {
-                                "password": {
-                                    "Ref": "RabbitMQLogstashInternalPassword"
-                                },
-                                "user": {
-                                    "Ref": "RabbitMQLogstashInternalUser"
-                                }
-                            }
-                        ]
-                    },
-                    "route53": {
-                        "domain_name": {
-                            "Ref": "Route53DomainName"
-                        },
-                        "zone_id": {
-                            "Ref": "Route53ZoneId"
-                        }
-                    },
-                    "statsd": {
-                        "graphite_host": {
-                            "Fn::GetAtt": [
-                                "GraphiteELB",
-                                "DNSName"
-                            ]
-                        },
-                        "nodejs_bin": "/usr/local/bin/node",
-                        "rabbitmq": {
-                            "password": {
-                                "Ref": "RabbitMQStatsdPassword"
-                            },
-                            "user": "statsd",
-                            "vhost": "/statsd"
-                        }
-                    }
-                },
-                "DefaultInstanceProfileArn": {
-                    "Fn::GetAtt": [
-                        "OpsWorksInstanceProfile",
-                        "Arn"
-                    ]
-                },
-                "DefaultOs": "Ubuntu 14.04 LTS",
-                "DefaultSubnetId": {
-                    "Ref": "PrivateSubnet"
-                },
-                "Name": {
-                    "Ref": "AWS::StackName"
-                },
-                "ServiceRoleArn": {
-                    "Fn::GetAtt": [
-                        "OpsWorksServiceRole",
-                        "Arn"
-                    ]
-                },
-                "UseCustomCookbooks": true,
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::OpsWorks::Stack"
-        },
-        "OutBoundPrivateNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
-                "NetworkAclId": {
-                    "Ref": "PrivateNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "0",
-                    "To": "65535"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "OutboundPublicNetworkAclEntry": {
-            "Properties": {
-                "CidrBlock": "0.0.0.0/0",
-                "Egress": "true",
-                "NetworkAclId": {
-                    "Ref": "PublicNetworkAcl"
-                },
-                "PortRange": {
-                    "From": "0",
-                    "To": "65535"
-                },
-                "Protocol": "6",
-                "RuleAction": "allow",
-                "RuleNumber": "100"
-            },
-            "Type": "AWS::EC2::NetworkAclEntry"
-        },
-        "PrivateNetworkAcl": {
-            "Properties": {
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::NetworkAcl"
-        },
-        "PrivateRoute": {
-            "Properties": {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "InstanceId": {
-                    "Ref": "NATDevice"
-                },
-                "RouteTableId": {
-                    "Ref": "PrivateRouteTable"
-                }
-            },
-            "Type": "AWS::EC2::Route"
-        },
-        "PrivateRouteTable": {
-            "Properties": {
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Private"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::RouteTable"
-        },
-        "PrivateSubnet": {
-            "Properties": {
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "0",
-                        {
-                            "Fn::GetAZs": {
-                                "Ref": "AWS::Region"
-                            }
-                        }
-                    ]
-                },
-                "CidrBlock": {
-                    "Fn::FindInMap": [
-                        "SubnetConfig",
-                        "Private",
-                        "CIDR"
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Name",
-                        "Value": "Private"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::Subnet"
-        },
-        "PrivateSubnetNetworkAclAssociation": {
-            "Properties": {
-                "NetworkAclId": {
-                    "Ref": "PrivateNetworkAcl"
-                },
-                "SubnetId": {
-                    "Ref": "PrivateSubnet"
-                }
-            },
-            "Type": "AWS::EC2::SubnetNetworkAclAssociation"
-        },
-        "PrivateSubnetRouteTableAssociation": {
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PrivateRouteTable"
-                },
-                "SubnetId": {
-                    "Ref": "PrivateSubnet"
-                }
-            },
-            "Type": "AWS::EC2::SubnetRouteTableAssociation"
-        },
-        "PublicNetworkAcl": {
-            "Properties": {
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::NetworkAcl"
-        },
-        "PublicRoute": {
-            "DependsOn": "VPCGatewayAttachment",
-            "Properties": {
-                "DestinationCidrBlock": "0.0.0.0/0",
-                "GatewayId": {
-                    "Ref": "InternetGateway"
-                },
-                "RouteTableId": {
-                    "Ref": "PublicRouteTable"
-                }
-            },
-            "Type": "AWS::EC2::Route"
-        },
-        "PublicRouteTable": {
-            "Properties": {
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::RouteTable"
-        },
-        "PublicSubnet": {
-            "Properties": {
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "0",
-                        {
-                            "Fn::GetAZs": {
-                                "Ref": "AWS::Region"
-                            }
-                        }
-                    ]
-                },
-                "CidrBlock": {
-                    "Fn::FindInMap": [
-                        "SubnetConfig",
-                        "Public",
-                        "CIDR"
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::Subnet"
-        },
-        "PublicSubnetNetworkAclAssociation": {
-            "Properties": {
-                "NetworkAclId": {
-                    "Ref": "PublicNetworkAcl"
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet"
-                }
-            },
-            "Type": "AWS::EC2::SubnetNetworkAclAssociation"
-        },
-        "PublicSubnetRouteTableAssociation": {
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "PublicRouteTable"
-                },
-                "SubnetId": {
-                    "Ref": "PublicSubnet"
-                }
-            },
-            "Type": "AWS::EC2::SubnetRouteTableAssociation"
-        },
-        "RabbitMQELB": {
-            "Properties": {
-                "HealthCheck": {
-                    "HealthyThreshold": "3",
-                    "Interval": "90",
-                    "Target": "TCP:5672",
-                    "Timeout": "60",
-                    "UnhealthyThreshold": "5"
-                },
-                "Listeners": [
-                    {
-                        "InstancePort": "5672",
-                        "LoadBalancerPort": "5672",
-                        "Protocol": "TCP"
-                    },
-                    {
-                        "InstancePort": "15672",
-                        "LoadBalancerPort": "15672",
-                        "Protocol": "TCP"
-                    },
-                    {
-                        "InstancePort": "5672",
-                        "LoadBalancerPort": "5671",
-                        "Protocol": "SSL",
-                        "SSLCertificateId": {
-                            "Ref": "RabbitMQCertificateARN"
-                        }
-                    }
-                ],
-                "SecurityGroups": [
-                    {
-                        "Ref": "RabbitMQELBSecurityGroup"
-                    },
-                    {
-                        "Ref": "InternalSecurityGroup"
-                    }
-                ],
-                "Subnets": [
-                    {
-                        "Ref": "PublicSubnet"
-                    }
-                ]
-            },
-            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
-        },
-        "RabbitMQELBAttachment": {
-            "Properties": {
-                "ElasticLoadBalancerName": {
-                    "Ref": "RabbitMQELB"
-                },
-                "LayerId": {
-                    "Ref": "OpsWorksRabbitMQLayer"
-                }
-            },
-            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
-        },
-        "RabbitMQELBSecurityGroup": {
-            "Properties": {
-                "GroupDescription": "Allow inbound access to the ELB",
-                "SecurityGroupEgress": [
-                    {
-                        "CidrIp": "0.0.0.0/0",
-                        "FromPort": "5671",
-                        "IpProtocol": "tcp",
-                        "ToPort": "5671"
-                    }
-                ],
-                "SecurityGroupIngress": [
-                    {
-                        "CidrIp": "0.0.0.0/0",
-                        "FromPort": "5671",
-                        "IpProtocol": "tcp",
-                        "ToPort": "5671"
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::SecurityGroup"
-        },
-        "RabbitMQInstance1": {
-            "Properties": {
-                "InstanceType": {
-                    "Ref": "RabbitMQInstanceType"
-                },
-                "LayerIds": [
-                    {
-                        "Ref": "OpsWorksRabbitMQLayer"
-                    }
-                ],
-                "StackId": {
-                    "Ref": "OpsWorksStack"
-                }
-            },
-            "Type": "AWS::OpsWorks::Instance"
-        },
-        "VPC": {
-            "DependsOn": "OpsWorksServiceRole",
-            "Properties": {
-                "CidrBlock": {
-                    "Fn::FindInMap": [
-                        "SubnetConfig",
-                        "VPC",
-                        "CIDR"
-                    ]
-                },
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Network",
-                        "Value": "Public"
-                    }
-                ]
-            },
-            "Type": "AWS::EC2::VPC"
-        },
-        "VPCGatewayAttachment": {
-            "Properties": {
-                "InternetGatewayId": {
-                    "Ref": "InternetGateway"
-                },
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::VPCGatewayAttachment"
-        }
+    "Version": {
+      "Description": "Just a place holder for version",
+      "Type": "String",
+      "Default": "0.1"
+    },
+    "RabbitMQCertificateARN": {
+      "Description": "ARN of hte certificate to use for rabbitmq",
+      "Type": "String"
+    },
+    "GithubOauthAppId": {
+      "Description": "Github Oauth App Id to use for doorman authentication. Leave empty for none.",
+      "Type": "String",
+      "Default": ""
+    },
+    "GithubOauthSecret": {
+      "Description": "Github Oauth App Secret to use for doorman authentication. Leave empty for none.",
+      "Type": "String",
+      "NoEcho": "true",
+      "Default": ""
+    },
+    "GithubOauthOrganization": {
+      "Description": "Github Organization to allow through doorman",
+      "Type": "String",
+      "Default": ""
+    },
+    "DoormanEnable": {
+        "Description": "Protect all internal resources through Doorman? If you are not deploying this privately through a VPN, this is recommended",
+        "Type": "String",
+        "Default": "true",
+        "AllowedValues": ["true","false"]
+    },
+    "DoormanSessionSecret": {
+      "Description": "A Secret Salt used to encrypt cookies for doorman",
+      "Type": "String",
+      "NoEcho": "true",
+      "Default": ""
+    },
+    "DoormanPassword": {
+      "Description": "Password to use for alternate authentication through doorman. Leave empty for none",
+      "Type": "String",
+      "Default": ""
+    },
+    "OpsWorksStackColor": {
+      "Description": "RGB Color to use for OpsWorks Stack",
+      "Type": "String",
+      "Default": "rgb(45, 114, 184)"
+    },
+    "BastionInstanceType":{
+        "Type" : "String",
+        "Default" : "m3.medium",
+        "AllowedValues" : ["t2.small", "t2.medium", "m3.medium" ],
+        "Description" : "Enter t2.small, t2.medium, m3.medium. Default is t2.small."
+    },
+    "RabbitMQInstanceType":{
+        "Type" : "String",
+        "Default" : "r3.large",
+        "AllowedValues" : ["m3.large", "c3.large", "r3.large"],
+        "Description" : "Enter m3.large, c3.large, or r3.large. Default is r3.large."
+    },
+    "GraphiteInstanceType":{
+        "Type" : "String",
+        "Default" : "c3.large",
+        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large"],
+        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large."
+    },
+    "ElasticSearchInstanceType":{
+        "Type" : "String",
+        "Default" : "r3.large",
+        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large"],
+        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is r3.large."
+    },
+    "LogstashInstanceType":{
+        "Type" : "String",
+        "Default" : "c3.large",
+        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large"],
+        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large."
+    },
+    "DashboardInstanceType":{
+        "Type" : "String",
+        "Default" : "c3.large",
+        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large", "m3.2xlarge"],
+        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large."
+    },
+    "RabbitMQUser": {
+      "Description": "RabbitMQ User",
+      "Type": "String",
+      "Default": "logger"
+    },
+    "RabbitMQErlangCookie": {
+      "Description": "RabbitMQ Erlang Cookie. This should be unique per stack",
+      "Type": "String",
+      "NoEcho": "true"
+    },
+    "RabbitMQPassword": {
+      "Description": "RabbitMQ Password",
+      "Type": "String",
+      "Default": "hunter2"
+    },
+    "RabbitMQLogstashInternalUser": {
+      "Description": "RabbitMQ User",
+      "Type": "String",
+      "Default": "logstash_internal"
+    },
+    "RabbitMQLogstashInternalPassword": {
+      "Description": "RabbitMQ Password",
+      "Type": "String"
+    },
+    "RabbitMQLogstashExternalUser": {
+      "Description": "RabbitMQ User",
+      "Type": "String",
+      "Default": "logstash_external"
+    },
+    "RabbitMQLogstashExternalPassword": {
+      "Description": "RabbitMQ Password",
+      "Type": "String"
+    },
+    "RabbitMQSensuPassword": {
+      "Description": "RabbitMQ Sensu Password",
+      "Type": "String"
+    },
+    "RabbitMQStatsdPassword": {
+      "Description": "RabbitMQ Statsd Password",
+      "Type": "String"
+    },
+    "GraphiteVolumeSize": {
+      "Description": "Size of disk in GB to use for graphite ebs volumes",
+      "Type": "Number",
+      "MinValue": 20,
+      "Default": 100
+    },
+    "ElasticSearchVolumeSize": {
+      "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
+      "Type": "Number",
+      "MinValue": 20,
+      "Default": 1000
+    },
+    "RabbitMQVolumeSize": {
+      "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
+      "Type": "Number",
+      "MinValue": 20,
+      "Default": 20
+    },
+    "Route53ZoneId": {
+      "Description": "The zone id to add dns records to on instance setup. If empty updates won't happen",
+      "Type": "String",
+      "Default": ""
+    },
+    "Route53DomainName": {
+      "Description": "The domain name to append to dns records",
+      "Type": "String",
+      "Default": ""
+    },
+    "PagerDutyAPIKey": {
+      "Description": "The pagerduty api key if you want sensu alerts forwarded to pagerduty",
+      "Type": "String",
+      "Default": ""
     }
+  },
+  "Mappings": {
+    "AWSNATAMI": {
+      "us-east-1": {
+        "AMI": "ami-c6699baf"
+      },
+      "us-west-2": {
+        "AMI": "ami-52ff7262"
+      },
+      "us-west-1": {
+        "AMI": "ami-3bcc9e7e"
+      },
+      "eu-west-1": {
+        "AMI": "ami-0b5b6c7f"
+      },
+      "ap-southeast-1": {
+        "AMI": "ami-02eb9350"
+      },
+      "ap-northeast-1": {
+        "AMI": "ami-14d86d15"
+      },
+      "sa-east-1": {
+        "AMI": "ami-0439e619"
+      }
+    },
+    "SubnetConfig": {
+      "VPC": {
+        "CIDR": "10.133.0.0/16"
+      },
+      "Public": {
+        "CIDR": "10.133.0.0/24"
+      },
+      "Private": {
+        "CIDR": "10.133.1.0/24"
+      }
+    }
+  },
+  "Resources": {
+    "OpsWorksStack": {
+      "Type": "AWS::OpsWorks::Stack",
+      "Properties": {
+        "Name": {
+          "Ref": "AWS::StackName"
+        },
+        "ConfigurationManager": {
+          "Name": "Chef",
+          "Version": "11.10"
+        },
+        "ChefConfiguration": {
+          "BerkshelfVersion": "3.1.3",
+          "ManageBerkshelf": true
+        },
+        "DefaultOs": "Ubuntu 14.04 LTS",
+        "UseCustomCookbooks": true,
+        "CustomCookbooksSource": {
+          "Revision": {
+            "Ref": "CookbooksRef"
+          },
+          "SshKey": {
+            "Ref": "CookbooksSshKey"
+          },
+          "Type": "git",
+          "Url": {
+            "Ref": "CookbooksRepo"
+          }
+        },
+        "Attributes": {
+          "Color": {
+            "Ref": "OpsWorksStackColor"
+          }
+        },
+        "ServiceRoleArn": {
+          "Fn::GetAtt": [
+            "OpsWorksServiceRole",
+            "Arn"
+          ]
+        },
+        "DefaultInstanceProfileArn": {
+          "Fn::GetAtt": [
+            "OpsWorksInstanceProfile",
+            "Arn"
+          ]
+        },
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "DefaultSubnetId": {
+          "Ref": "PrivateSubnet"
+        },
+        "CustomJson": {
+          "chef_environment": "production",
+          "route53": {
+            "zone_id": {
+              "Ref": "Route53ZoneId"
+            },
+            "domain_name": {
+              "Ref": "Route53DomainName"
+            }
+          },
+          "aws_region": {
+            "Ref": "AWS::Region"
+          },
+          "graphite": {
+            "host": {
+              "Fn::GetAtt": [
+                "GraphiteELB",
+                "DNSName"
+              ]
+            }
+          },
+          "elasticsearch": {
+            "version": "1.0.1",
+            "cluster": {
+              "name": "logstash"
+            },
+            "plugins": {
+              "elasticsearch/elasticsearch-cloud-aws": {
+                "version": "2.2.0"
+              }
+            },
+            "cloud": {
+              "aws": {
+                "region": {
+                  "Ref": "AWS::Region"
+                }
+              }
+            },
+            "discovery": {
+              "type": "ec2"
+            },
+            "http_auth": false,
+            "index.number_of_shards": 8,
+            "index.number_of_replicas": 2,
+            "index.auto_expand_replicas": "2-all"
+          },
+          "bb_monitor": {
+            "sensu": {
+              "server_url": {
+                "Fn::GetAtt": [
+                  "DashboardELB",
+                  "DNSName"
+                ]
+              },
+            "rabbitmq": {
+                "server": {
+                  "Fn::GetAtt": [
+                    "RabbitMQELB",
+                    "DNSName"
+                  ]
+                },
+                "password": {
+                  "Ref": "RabbitMQSensuPassword"
+                }
+              },
+              "pagerduty_api": {
+                "Ref": "PagerDutyAPIKey"
+              }
+            },
+            "logstash": {
+                "rabbitmq": { 
+                  "server": {
+                    "Fn::GetAtt": [
+                      "RabbitMQELB",
+                      "DNSName"
+                    ]
+                  },
+                  "password": {
+                    "Ref": "RabbitMQLogstashInternalPassword"
+                  }
+                },
+              "server": {
+                "elasticsearch_server": {
+                  "Fn::GetAtt": [
+                    "ElasticSearchELB",
+                    "DNSName"
+                  ]
+                },
+                "filters": [],
+                "statsd_output": {}
+              }
+            }
+          },
+          "rabbitmq": {
+            "cluster": true,
+            "erlang_cookie": {
+                "Ref": "RabbitMQErlangCookie"
+            }
+          },
+          "rabbitmq_cluster": {
+            "users": [
+              {
+                "user": {
+                  "Ref": "RabbitMQUser"
+                },
+                "password": {
+                  "Ref": "RabbitMQPassword"
+                }
+              },
+              {
+                "user": {
+                  "Ref": "RabbitMQLogstashExternalUser"
+                },
+                "password": {
+                  "Ref": "RabbitMQLogstashExternalPassword"
+                }
+              },
+              {
+                "user": {
+                  "Ref": "RabbitMQLogstashInternalUser"
+                },
+                "password": {
+                  "Ref": "RabbitMQLogstashInternalPassword"
+                }
+              }
+            ]
+          },
+          "kibana": {
+            "version": "3",
+            "kibana3_version": "3.1.1",
+            "elasticsearch_server": {
+              "Fn::GetAtt": [
+                "ElasticSearchELB",
+                "DNSName"
+              ]
+            }
+          },
+          "doorman": {
+            "password": {
+              "Ref": "DoormanEnable"
+            },
+            "session_secret":
+            {
+             "Ref": "DoormanSessionSecret"
+            },
+            "app_id": {
+              "Ref": "GithubOauthAppId"
+            },
+            "app_secret": {
+              "Ref": "GithubOauthSecret"
+            },
+            "org_name": {
+              "Ref": "GithubOauthOrganization"
+            },
+            "password": {
+              "Ref": "DoormanPassword"
+            }
+          },
+          "statsd": {
+            "graphite_host": {
+              "Fn::GetAtt": [
+                "GraphiteELB",
+                "DNSName"
+              ]
+            },
+            "nodejs_bin": "/usr/local/bin/node",
+            "rabbitmq": {
+              "vhost": "/statsd",
+              "user": "statsd",
+              "password": {
+                "Ref": "RabbitMQStatsdPassword"
+              }
+            }
+          }
+        }
+      }
+    },
+    "OpsWorksBastionLayer": {
+      "Type": "AWS::OpsWorks::Layer",
+      "Metadata": {
+        "Comment": "Put the bastion layer inside of opsworks so the same users that have access to opsworks will have access to bastion."
+      },
+      "DependsOn": [
+        "NATIPAddress",
+        "PublicRoute",
+        "PublicSubnetRouteTableAssociation",
+        "PrivateRoute",
+        "PrivateSubnetRouteTableAssociation"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "Name": "Bastion",
+        "Type": "custom",
+        "Shortname": "bastion",
+        "EnableAutoHealing": "true",
+        "AutoAssignElasticIps": "true",
+        "AutoAssignPublicIps": "false",
+        "CustomSecurityGroupIds": [
+          {
+            "Ref": "OpsWorksSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "CustomRecipes": {
+          "Setup": [
+            "bb_monitor::route53",
+            "bb_monitor::logstash_agent"
+          ],
+          "Configure": [
+            "bb_monitor::sensu_client"
+          ],
+          "Deploy": [],
+          "Undeploy": [],
+          "Shutdown": []
+        }
+      }
+    },
+    "BastionInstance1": {
+      "Type": "AWS::OpsWorks::Instance",
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksBastionLayer"
+          }
+        ],
+        "InstanceType": { "Ref":"BastionInstanceType"} ,
+        "SubnetId": {
+          "Ref": "PublicSubnet"
+        }
+      }
+    },
+    "OpsWorksDashboardLayer": {
+      "Type": "AWS::OpsWorks::Layer",
+      "Metadata": {
+        "Comment": ""
+      },
+      "DependsOn": [
+        "NATIPAddress",
+        "PublicRoute",
+        "PublicSubnetRouteTableAssociation",
+        "PrivateRoute",
+        "PrivateSubnetRouteTableAssociation"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "Name": "Dashboard",
+        "Type": "custom",
+        "Shortname": "dashboard",
+        "EnableAutoHealing": "true",
+        "AutoAssignElasticIps": "false",
+        "AutoAssignPublicIps": "false",
+        "CustomSecurityGroupIds": [
+          {
+            "Ref": "OpsWorksSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "CustomRecipes": {
+          "Setup": [
+            "bb_monitor::kibana",
+            "bb_monitor::grafana",
+            "bb_monitor::sensu_server",
+            "bb_monitor::nginx",
+            "bb_monitor::route53",
+            "bb_monitor::logstash_agent"
+          ],
+          "Configure": [
+            "bb_monitor::sensu_client"
+          ],
+          "Deploy": [],
+          "Undeploy": [],
+          "Shutdown": []
+        }
+      }
+    },
+    "DashboardInstance1": {
+      "Type": "AWS::OpsWorks::Instance",
+      "DependsOn": [
+        "RabbitMQInstance1",
+        "GraphiteInstance1"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksDashboardLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "DashboardInstanceType" }
+      }
+    },
+    "OpsWorksGraphiteLayer": {
+      "Type": "AWS::OpsWorks::Layer",
+      "Metadata": {
+        "Comment": ""
+      },
+      "DependsOn": [
+        "NATIPAddress",
+        "PublicRoute",
+        "PublicSubnetRouteTableAssociation",
+        "PrivateRoute",
+        "PrivateSubnetRouteTableAssociation"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "Name": "Graphite",
+        "Type": "custom",
+        "Shortname": "graphite",
+        "EnableAutoHealing": "true",
+        "AutoAssignElasticIps": "false",
+        "AutoAssignPublicIps": "false",
+        "CustomSecurityGroupIds": [
+          {
+            "Ref": "OpsWorksSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "CustomRecipes": {
+          "Setup": [
+            "bb_monitor::graphite",
+            "bb_monitor::route53",
+            "bb_monitor::logstash_agent"
+          ],
+          "Configure": [
+            "bb_monitor::sensu_client"
+          ],
+          "Deploy": [],
+          "Undeploy": [],
+          "Shutdown": [
+            "bb_monitor::sensu_client_remove"
+          ]
+        },
+        "VolumeConfigurations": [
+          {
+            "MountPoint": "/opt/graphite/storage",
+            "NumberOfDisks": 1,
+            "Size": {
+              "Ref": "GraphiteVolumeSize"
+            }
+          }
+        ]
+      }
+    },
+    "GraphiteInstance1": {
+      "Type": "AWS::OpsWorks::Instance",
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksGraphiteLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "GraphiteInstanceType" }
+      }
+    },
+    "OpsWorksElasticSearchLayer": {
+      "Type": "AWS::OpsWorks::Layer",
+      "Metadata": {
+        "Comment": ""
+      },
+      "DependsOn": [
+        "NATIPAddress",
+        "PublicRoute",
+        "PublicSubnetRouteTableAssociation",
+        "PrivateRoute",
+        "PrivateSubnetRouteTableAssociation"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "Name": "ElasticSearch",
+        "Type": "custom",
+        "Shortname": "elasticsearch",
+        "EnableAutoHealing": "true",
+        "AutoAssignElasticIps": "false",
+        "AutoAssignPublicIps": "false",
+        "CustomSecurityGroupIds": [
+          {
+            "Ref": "OpsWorksSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "CustomRecipes": {
+          "Setup": [
+            "bb_elasticsearch",
+            "bb_monitor::route53",
+            "bb_monitor::logstash_agent"
+          ],
+          "Configure": [
+            "bb_monitor::sensu_client"
+          ],
+          "Deploy": [],
+          "Undeploy": [],
+          "Shutdown": [
+            "bb_monitor::sensu_client_remove"
+          ]
+        },
+        "VolumeConfigurations": [
+          {
+            "MountPoint": "/usr/local/var",
+            "NumberOfDisks": 1,
+            "Size": {
+              "Ref": "ElasticSearchVolumeSize"
+            }
+          }
+        ]
+      }
+    },
+    "ElasticSearchInstance1": {
+      "Type": "AWS::OpsWorks::Instance",
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksElasticSearchLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
+      }
+    },
+    "ElasticSearchInstance2": {
+      "Type": "AWS::OpsWorks::Instance",
+      "DependsOn": [
+        "ElasticSearchInstance1"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksElasticSearchLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
+      }
+    },
+    "ElasticSearchInstance3": {
+      "Type": "AWS::OpsWorks::Instance",
+      "DependsOn": [
+        "ElasticSearchInstance2"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksElasticSearchLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
+      }
+    },
+    "OpsWorksRabbitMQLayer": {
+      "Type": "AWS::OpsWorks::Layer",
+      "Metadata": {
+        "Comment": ""
+      },
+      "DependsOn": [
+        "NATIPAddress",
+        "PublicRoute",
+        "PublicSubnetRouteTableAssociation",
+        "PrivateRoute",
+        "PrivateSubnetRouteTableAssociation"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "Name": "RabbitMQ",
+        "Type": "custom",
+        "Shortname": "rabbitmq",
+        "EnableAutoHealing": "true",
+        "AutoAssignElasticIps": "false",
+        "AutoAssignPublicIps": "false",
+        "CustomSecurityGroupIds": [
+          {
+            "Ref": "OpsWorksSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "CustomRecipes": {
+          "Setup": [
+            "rabbitmq_cluster",
+            "bb_monitor::route53",
+            "bb_monitor::logstash_agent"
+          ],
+          "Configure": [
+            "bb_monitor::sensu_client"
+          ],
+          "Deploy": [],
+          "Undeploy": [],
+          "Shutdown": [
+            "bb_monitor::sensu_client_remove"
+          ]
+        },
+        "VolumeConfigurations": [
+          {
+            "MountPoint": "/var/lib/rabbitmq",
+            "NumberOfDisks": 1,
+            "Size": {
+              "Ref": "RabbitMQVolumeSize"
+            }
+          }
+        ]
+      }
+    },
+    "RabbitMQInstance1": {
+      "Type": "AWS::OpsWorks::Instance",
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksRabbitMQLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "RabbitMQInstanceType" }
+      }
+    },
+    "OpsWorksLogstashLayer": {
+      "Type": "AWS::OpsWorks::Layer",
+      "Metadata": {
+        "Comment": ""
+      },
+      "DependsOn": [
+        "NATIPAddress",
+        "PublicRoute",
+        "PublicSubnetRouteTableAssociation",
+        "PrivateRoute",
+        "PrivateSubnetRouteTableAssociation"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "Name": "Logstash",
+        "Type": "custom",
+        "Shortname": "logstash",
+        "EnableAutoHealing": "true",
+        "AutoAssignElasticIps": "false",
+        "AutoAssignPublicIps": "false",
+        "CustomSecurityGroupIds": [
+          {
+            "Ref": "OpsWorksSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "CustomRecipes": {
+          "Setup": [
+            "bb_monitor::route53",
+            "bb_monitor::logstash_server"
+          ],
+          "Configure": [
+            "bb_monitor::sensu_client"
+          ],
+          "Deploy": [],
+          "Undeploy": [],
+          "Shutdown": [
+            "bb_monitor::sensu_client_remove"
+          ]
+        }
+      }
+    },
+    "LogstashInstance1": {
+      "Type": "AWS::OpsWorks::Instance",
+      "DependsOn": [
+        "ElasticSearchInstance1",
+        "ElasticSearchInstance2",
+        "ElasticSearchInstance3",
+        "RabbitMQInstance1"
+      ],
+      "Properties": {
+        "StackId": {
+          "Ref": "OpsWorksStack"
+        },
+        "LayerIds": [
+          {
+            "Ref": "OpsWorksLogstashLayer"
+          }
+        ],
+        "InstanceType": { "Ref" : "LogstashInstanceType" }
+      }
+    },
+    "OpsWorksServiceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "opsworks.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "opsworks-service",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2:*",
+                    "iam:PassRole",
+                    "cloudwatch:GetMetricStatistics",
+                    "elasticloadbalancing:*"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "OpsWorksInstanceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "opsworks-instance-ec2",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2:CreateSnapshot",
+                    "ec2:CreateTags",
+                    "ec2:DeleteSnapshot",
+                    "ec2:Describe*"
+                  ],
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "opsworks-opsworks",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "opsworks:*",
+                    "ec2:DescribeKeyPairs",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeAccountAttributes",
+                    "ec2:DescribeAvailabilityZones",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeVpcs",
+                    "elasticloadbalancing:DescribeInstanceHealth",
+                    "elasticloadbalancing:DescribeLoadBalancers",
+                    "iam:GetRolePolicy",
+                    "iam:ListInstanceProfiles",
+                    "iam:ListRoles",
+                    "iam:ListUsers",
+                    "iam:PassRole"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "opsworks-route53",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "route53:*"
+                  ],
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "opsworks-instance-cloudwatch",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "autoscaling:Describe*",
+                    "cloudwatch:Describe*",
+                    "cloudwatch:Get*",
+                    "cloudwatch:List*",
+                    "logs:Get*",
+                    "logs:Describe*",
+                    "logs:TestMetricFilter",
+                    "sns:Get*",
+                    "sns:List*"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "opsworks-instance-elb",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "elasticloadbalancing:DescribeInstanceHealth",
+                    "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                    "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
+                    "elasticloadbalancing:DescribeLoadBalancerPolicies",
+                    "elasticloadbalancing:DescribeLoadBalancers",
+                    "elasticloadbalancing:DescribeTags"
+                  ],
+                  "Resource": [
+                    "*"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "OpsWorksInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "OpsWorksInstanceRole"
+          }
+        ]
+      }
+    },
+    "OpsWorksSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow inbound requests from the ELB to the OpsWorks instances",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "SourceSecurityGroupId": {
+              "Ref": "DashboardELBSecurityGroup"
+            }
+          }
+        ]
+      }
+    },
+    "DashboardELB": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "DashboardELBSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "Subnets": [
+          {
+            "Ref": "PublicSubnet"
+          }
+        ],
+        "Listeners": [
+          {
+            "LoadBalancerPort": "80",
+            "InstancePort": "80",
+            "Protocol": "HTTP"
+          },
+          {
+            "LoadBalancerPort": "6379",
+            "InstancePort": "6379",
+            "Protocol": "TCP"
+          },
+          {
+            "LoadBalancerPort": "4567",
+            "InstancePort": "4567",
+            "Protocol": "TCP"
+          }
+        ],
+        "HealthCheck": {
+          "Target": "HTTP:80/",
+          "HealthyThreshold": "3",
+          "UnhealthyThreshold": "5",
+          "Interval": "90",
+          "Timeout": "60"
+        }
+      }
+    },
+    "DashboardELBAttachment": {
+      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
+      "Properties": {
+        "ElasticLoadBalancerName": {
+          "Ref": "DashboardELB"
+        },
+        "LayerId": {
+          "Ref": "OpsWorksDashboardLayer"
+        }
+      }
+    },
+    "DashboardELBSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow inbound access to the ELB",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ],
+        "SecurityGroupEgress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "RabbitMQELB": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "RabbitMQELBSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "Subnets": [
+          {
+            "Ref": "PublicSubnet"
+          }
+        ],
+        "Listeners": [
+          {
+            "LoadBalancerPort": "5672",
+            "InstancePort": "5672",
+            "Protocol": "TCP"
+          },
+          {
+            "LoadBalancerPort": "15672",
+            "InstancePort": "15672",
+            "Protocol": "TCP"
+          },
+          {
+            "LoadBalancerPort": "5671",
+            "InstancePort": "5672",
+            "Protocol": "SSL",
+            "SSLCertificateId": {
+              "Ref": "RabbitMQCertificateARN"
+            }
+          }
+        ],
+        "HealthCheck": {
+          "Target": "TCP:5672",
+          "HealthyThreshold": "3",
+          "UnhealthyThreshold": "5",
+          "Interval": "90",
+          "Timeout": "60"
+        }
+      }
+    },
+    "RabbitMQELBAttachment": {
+      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
+      "Properties": {
+        "ElasticLoadBalancerName": {
+          "Ref": "RabbitMQELB"
+        },
+        "LayerId": {
+          "Ref": "OpsWorksRabbitMQLayer"
+        }
+      }
+    },
+    "RabbitMQELBSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow inbound access to the ELB",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "5671",
+            "ToPort": "5671",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ],
+        "SecurityGroupEgress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "5671",
+            "ToPort": "5671",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "ElasticSearchELB": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "Subnets": [
+          {
+            "Ref": "PrivateSubnet"
+          }
+        ],
+        "Scheme": "internal",
+        "Listeners": [
+          {
+            "LoadBalancerPort": "9200",
+            "InstancePort": "9200",
+            "Protocol": "TCP"
+          },
+          {
+            "LoadBalancerPort": "9300",
+            "InstancePort": "9300",
+            "Protocol": "TCP"
+          }
+        ],
+        "HealthCheck": {
+          "Target": "TCP:9200",
+          "HealthyThreshold": "3",
+          "UnhealthyThreshold": "5",
+          "Interval": "90",
+          "Timeout": "60"
+        }
+      }
+    },
+    "ElasticSearchELBAttachment": {
+      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
+      "Properties": {
+        "ElasticLoadBalancerName": {
+          "Ref": "ElasticSearchELB"
+        },
+        "LayerId": {
+          "Ref": "OpsWorksElasticSearchLayer"
+        }
+      }
+    },
+    "GraphiteELB": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "Subnets": [
+          {
+            "Ref": "PrivateSubnet"
+          }
+        ],
+        "Scheme": "internal",
+        "Listeners": [
+          {
+            "LoadBalancerPort": "8081",
+            "InstancePort": "8081",
+            "Protocol": "TCP"
+          },
+          {
+            "LoadBalancerPort": "2003",
+            "InstancePort": "2003",
+            "Protocol": "TCP"
+          }
+        ],
+        "HealthCheck": {
+          "Target": "TCP:2003",
+          "HealthyThreshold": "3",
+          "UnhealthyThreshold": "5",
+          "Interval": "90",
+          "Timeout": "60"
+        }
+      }
+    },
+    "GraphiteELBAttachment": {
+      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
+      "Properties": {
+        "ElasticLoadBalancerName": {
+          "Ref": "GraphiteELB"
+        },
+        "LayerId": {
+          "Ref": "OpsWorksGraphiteLayer"
+        }
+      }
+    },
+    "InternalSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow VPC access to ports running on dashboard server",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Fn::FindInMap": [
+                "SubnetConfig",
+                "VPC",
+                "CIDR"
+              ]
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "SourceSecurityGroupId": {
+              "Ref": "DashboardELBSecurityGroup"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "NATIPAddress"
+                  },
+                  "/32"
+                ]
+              ]
+            }
+          }
+        ],
+        "SecurityGroupEgress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    "VPC": {
+      "Type": "AWS::EC2::VPC",
+      "DependsOn": "OpsWorksServiceRole",
+      "Properties": {
+        "CidrBlock": {
+          "Fn::FindInMap": [
+            "SubnetConfig",
+            "VPC",
+            "CIDR"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "PublicSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::GetAZs": {
+                "Ref": "AWS::Region"
+              }
+            }
+          ]
+        },
+        "CidrBlock": {
+          "Fn::FindInMap": [
+            "SubnetConfig",
+            "Public",
+            "CIDR"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "InternetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "VPCGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "InternetGatewayId": {
+          "Ref": "InternetGateway"
+        }
+      }
+    },
+    "PublicRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "PublicRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "VPCGatewayAttachment",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "InternetGateway"
+        }
+      }
+    },
+    "PublicSubnetRouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnet"
+        },
+        "RouteTableId": {
+          "Ref": "PublicRouteTable"
+        }
+      }
+    },
+    "PublicNetworkAcl": {
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Public"
+          }
+        ]
+      }
+    },
+    "InboundHTTPPublicNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PublicNetworkAcl"
+        },
+        "RuleNumber": "100",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "false",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "80",
+          "To": "80"
+        }
+      }
+    },
+    "InboundHTTPSPublicNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PublicNetworkAcl"
+        },
+        "RuleNumber": "101",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "false",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "443",
+          "To": "443"
+        }
+      }
+    },
+    "InboundSSHPublicNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PublicNetworkAcl"
+        },
+        "RuleNumber": "102",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "false",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "22",
+          "To": "22"
+        }
+      }
+    },
+    "InboundEmphemeralPublicNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PublicNetworkAcl"
+        },
+        "RuleNumber": "103",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "false",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "1024",
+          "To": "65535"
+        }
+      }
+    },
+    "OutboundPublicNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PublicNetworkAcl"
+        },
+        "RuleNumber": "100",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "true",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "0",
+          "To": "65535"
+        }
+      }
+    },
+    "PublicSubnetNetworkAclAssociation": {
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PublicSubnet"
+        },
+        "NetworkAclId": {
+          "Ref": "PublicNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::GetAZs": {
+                "Ref": "AWS::Region"
+              }
+            }
+          ]
+        },
+        "CidrBlock": {
+          "Fn::FindInMap": [
+            "SubnetConfig",
+            "Private",
+            "CIDR"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Name",
+            "Value": "Private"
+          }
+        ]
+      }
+    },
+    "PrivateRouteTable": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          }
+        ]
+      }
+    },
+    "PrivateSubnetRouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      }
+    },
+    "PrivateRoute": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "InstanceId": {
+          "Ref": "NATDevice"
+        }
+      }
+    },
+    "PrivateNetworkAcl": {
+      "Type": "AWS::EC2::NetworkAcl",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Network",
+            "Value": "Private"
+          }
+        ]
+      }
+    },
+    "InboundPrivateNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkAcl"
+        },
+        "RuleNumber": "100",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "false",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "0",
+          "To": "65535"
+        }
+      }
+    },
+    "OutBoundPrivateNetworkAclEntry": {
+      "Type": "AWS::EC2::NetworkAclEntry",
+      "Properties": {
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkAcl"
+        },
+        "RuleNumber": "100",
+        "Protocol": "6",
+        "RuleAction": "allow",
+        "Egress": "true",
+        "CidrBlock": "0.0.0.0/0",
+        "PortRange": {
+          "From": "0",
+          "To": "65535"
+        }
+      }
+    },
+    "PrivateSubnetNetworkAclAssociation": {
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkAcl"
+        }
+      }
+    },
+    "NATIPAddress": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "InstanceId": {
+          "Ref": "NATDevice"
+        }
+      }
+    },
+    "NATDevice": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "InstanceType": "m1.small",
+        "SubnetId": {
+          "Ref": "PublicSubnet"
+        },
+        "SourceDestCheck": "false",
+        "ImageId": {
+          "Fn::FindInMap": [
+            "AWSNATAMI",
+            {
+              "Ref": "AWS::Region"
+            },
+            "AMI"
+          ]
+        },
+        "SecurityGroupIds": [
+          {
+            "Ref": "NATSecurityGroup"
+          }
+        ]
+      }
+    },
+    "NATSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow OpsWorks instances to access the NAT Device",
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "80",
+            "ToPort": "80",
+            "SourceSecurityGroupId": {
+              "Ref": "OpsWorksSecurityGroup"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "9418",
+            "ToPort": "9418",
+            "SourceSecurityGroupId": {
+              "Ref": "OpsWorksSecurityGroup"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "SourceSecurityGroupId": {
+              "Ref": "OpsWorksSecurityGroup"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Fn::FindInMap": [
+                "SubnetConfig",
+                "VPC",
+                "CIDR"
+              ]
+            }
+          }
+        ],
+        "SecurityGroupEgress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "StackId": {
+      "Value": {
+        "Ref": "OpsWorksStack"
+      }
+    },
+    "VPC": {
+      "Description": "VPC",
+      "Value": {
+        "Ref": "VPC"
+      }
+    },
+    "PublicSubnet": {
+      "Value": {
+        "Ref": "PublicSubnet"
+      }
+    },
+    "PrivateSubnet": {
+      "Value": {
+        "Ref": "PrivateSubnet"
+      }
+    },
+    "DashboardUrl": {
+      "Value": {
+        "Fn::GetAtt": [
+          "DashboardELB",
+          "DNSName"
+        ]
+      }
+    }
+  }
 }

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -863,6 +863,7 @@
         "ElasticSearchInstance1",
         "ElasticSearchInstance2",
         "ElasticSearchInstance3",
+        "DashboardInstance1",
         "RabbitMQInstance1"
       ],
       "Properties": {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -1,1898 +1,1944 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "",
-  "Parameters": {
-    "CookbooksRepo": {
-      "Description": "The github url for your custom cookbooks",
-      "Type": "String"
-    },
-    "CookbooksRef": {
-      "Description": "The git reference to checkout for custom cookbooks",
-      "Type": "String",
-      "Default": "master"
-    },
-    "CookbooksSshKey": {
-      "Description": "The ssh key needed to clone the cookbooks repo",
-      "Type": "String",
-      "NoEcho": "true",
-      "Default": ""
-    },
-    "Version": {
-      "Description": "Just a place holder for version",
-      "Type": "String",
-      "Default": "0.1"
-    },
-    "RabbitMQCertificateARN": {
-      "Description": "ARN of hte certificate to use for rabbitmq",
-      "Type": "String"
-    },
-    "GithubOauthAppId": {
-      "Description": "Github Oauth App Id to use for doorman authentication. Leave empty for none.",
-      "Type": "String",
-      "Default": ""
-    },
-    "GithubOauthSecret": {
-      "Description": "Github Oauth App Secret to use for doorman authentication. Leave empty for none.",
-      "Type": "String",
-      "NoEcho": "true",
-      "Default": ""
-    },
-    "GithubOauthOrganization": {
-      "Description": "Github Organization to allow through doorman",
-      "Type": "String",
-      "Default": ""
-    },
-    "DoormanEnable": {
-        "Description": "Protect all internal resources through Doorman? If you are not deploying this privately through a VPN, this is recommended",
-        "Type": "String",
-        "Default": "true",
-        "AllowedValues": ["true","false"]
-    },
-    "DoormanSessionSecret": {
-      "Description": "A Secret Salt used to encrypt cookies for doorman",
-      "Type": "String",
-      "NoEcho": "true",
-      "Default": ""
-    },
-    "DoormanPassword": {
-      "Description": "Password to use for alternate authentication through doorman. Leave empty for none",
-      "Type": "String",
-      "Default": ""
-    },
-    "OpsWorksStackColor": {
-      "Description": "RGB Color to use for OpsWorks Stack",
-      "Type": "String",
-      "Default": "rgb(45, 114, 184)"
-    },
-    "BastionInstanceType":{
-        "Type" : "String",
-        "Default" : "m3.medium",
-        "AllowedValues" : ["t2.small", "t2.medium", "m3.medium" ],
-        "Description" : "Enter t2.small, t2.medium, m3.medium. Default is t2.small."
-    },
-    "RabbitMQInstanceType":{
-        "Type" : "String",
-        "Default" : "r3.large",
-        "AllowedValues" : ["m3.large", "c3.large", "r3.large"],
-        "Description" : "Enter m3.large, c3.large, or r3.large. Default is r3.large."
-    },
-    "GraphiteInstanceType":{
-        "Type" : "String",
-        "Default" : "c3.large",
-        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large"],
-        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large."
-    },
-    "ElasticSearchInstanceType":{
-        "Type" : "String",
-        "Default" : "r3.large",
-        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large"],
-        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is r3.large."
-    },
-    "LogstashInstanceType":{
-        "Type" : "String",
-        "Default" : "c3.large",
-        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large"],
-        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large."
-    },
-    "DashboardInstanceType":{
-        "Type" : "String",
-        "Default" : "c3.large",
-        "AllowedValues" : ["m3.medium", "m3.large", "c3.large", "r3.large", "m3.2xlarge"],
-        "Description" : "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large."
-    },
-    "RabbitMQUser": {
-      "Description": "RabbitMQ User",
-      "Type": "String",
-      "Default": "logger"
-    },
-    "RabbitMQErlangCookie": {
-      "Description": "RabbitMQ Erlang Cookie. This should be unique per stack",
-      "Type": "String",
-      "NoEcho": "true"
-    },
-    "RabbitMQPassword": {
-      "Description": "RabbitMQ Password",
-      "Type": "String",
-      "Default": "hunter2"
-    },
-    "RabbitMQLogstashInternalUser": {
-      "Description": "RabbitMQ User",
-      "Type": "String",
-      "Default": "logstash_internal"
-    },
-    "RabbitMQLogstashInternalPassword": {
-      "Description": "RabbitMQ Password",
-      "Type": "String"
-    },
-    "RabbitMQLogstashExternalUser": {
-      "Description": "RabbitMQ User",
-      "Type": "String",
-      "Default": "logstash_external"
-    },
-    "RabbitMQLogstashExternalPassword": {
-      "Description": "RabbitMQ Password",
-      "Type": "String"
-    },
-    "RabbitMQSensuPassword": {
-      "Description": "RabbitMQ Sensu Password",
-      "Type": "String"
-    },
-    "RabbitMQStatsdPassword": {
-      "Description": "RabbitMQ Statsd Password",
-      "Type": "String"
-    },
-    "GraphiteVolumeSize": {
-      "Description": "Size of disk in GB to use for graphite ebs volumes",
-      "Type": "Number",
-      "MinValue": 20,
-      "Default": 100
-    },
-    "ElasticSearchVolumeSize": {
-      "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
-      "Type": "Number",
-      "MinValue": 20,
-      "Default": 1000
-    },
-    "RabbitMQVolumeSize": {
-      "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
-      "Type": "Number",
-      "MinValue": 20,
-      "Default": 20
-    },
-    "Route53ZoneId": {
-      "Description": "The zone id to add dns records to on instance setup. If empty updates won't happen",
-      "Type": "String",
-      "Default": ""
-    },
-    "Route53DomainName": {
-      "Description": "The domain name to append to dns records",
-      "Type": "String",
-      "Default": ""
-    },
-    "PagerDutyAPIKey": {
-      "Description": "The pagerduty api key if you want sensu alerts forwarded to pagerduty",
-      "Type": "String",
-      "Default": ""
-    }
-  },
-  "Mappings": {
-    "AWSNATAMI": {
-      "us-east-1": {
-        "AMI": "ami-c6699baf"
-      },
-      "us-west-2": {
-        "AMI": "ami-52ff7262"
-      },
-      "us-west-1": {
-        "AMI": "ami-3bcc9e7e"
-      },
-      "eu-west-1": {
-        "AMI": "ami-0b5b6c7f"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-02eb9350"
-      },
-      "ap-northeast-1": {
-        "AMI": "ami-14d86d15"
-      },
-      "sa-east-1": {
-        "AMI": "ami-0439e619"
-      }
-    },
-    "SubnetConfig": {
-      "VPC": {
-        "CIDR": "10.133.0.0/16"
-      },
-      "Public": {
-        "CIDR": "10.133.0.0/24"
-      },
-      "Private": {
-        "CIDR": "10.133.1.0/24"
-      }
-    }
-  },
-  "Resources": {
-    "OpsWorksStack": {
-      "Type": "AWS::OpsWorks::Stack",
-      "Properties": {
-        "Name": {
-          "Ref": "AWS::StackName"
-        },
-        "ConfigurationManager": {
-          "Name": "Chef",
-          "Version": "11.10"
-        },
-        "ChefConfiguration": {
-          "BerkshelfVersion": "3.1.3",
-          "ManageBerkshelf": true
-        },
-        "DefaultOs": "Ubuntu 14.04 LTS",
-        "UseCustomCookbooks": true,
-        "CustomCookbooksSource": {
-          "Revision": {
-            "Ref": "CookbooksRef"
-          },
-          "SshKey": {
-            "Ref": "CookbooksSshKey"
-          },
-          "Type": "git",
-          "Url": {
-            "Ref": "CookbooksRepo"
-          }
-        },
-        "Attributes": {
-          "Color": {
-            "Ref": "OpsWorksStackColor"
-          }
-        },
-        "ServiceRoleArn": {
-          "Fn::GetAtt": [
-            "OpsWorksServiceRole",
-            "Arn"
-          ]
-        },
-        "DefaultInstanceProfileArn": {
-          "Fn::GetAtt": [
-            "OpsWorksInstanceProfile",
-            "Arn"
-          ]
-        },
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "DefaultSubnetId": {
-          "Ref": "PrivateSubnet"
-        },
-        "CustomJson": {
-          "chef_environment": "production",
-          "route53": {
-            "zone_id": {
-              "Ref": "Route53ZoneId"
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "",
+    "Mappings": {
+        "AWSNATAMI": {
+            "ap-northeast-1": {
+                "AMI": "ami-14d86d15"
             },
-            "domain_name": {
-              "Ref": "Route53DomainName"
+            "ap-southeast-1": {
+                "AMI": "ami-02eb9350"
+            },
+            "eu-west-1": {
+                "AMI": "ami-0b5b6c7f"
+            },
+            "sa-east-1": {
+                "AMI": "ami-0439e619"
+            },
+            "us-east-1": {
+                "AMI": "ami-c6699baf"
+            },
+            "us-west-1": {
+                "AMI": "ami-3bcc9e7e"
+            },
+            "us-west-2": {
+                "AMI": "ami-52ff7262"
             }
-          },
-          "aws_region": {
-            "Ref": "AWS::Region"
-          },
-          "graphite": {
-            "host": {
-              "Fn::GetAtt": [
-                "GraphiteELB",
-                "DNSName"
-              ]
+        },
+        "SubnetConfig": {
+            "Private": {
+                "CIDR": "10.133.1.0/24"
+            },
+            "Public": {
+                "CIDR": "10.133.0.0/24"
+            },
+            "VPC": {
+                "CIDR": "10.133.0.0/16"
             }
-          },
-          "elasticsearch": {
-            "version": "1.0.1",
-            "cluster": {
-              "name": "logstash"
-            },
-            "plugins": {
-              "elasticsearch/elasticsearch-cloud-aws": {
-                "version": "2.2.0"
-              }
-            },
-            "cloud": {
-              "aws": {
-                "region": {
-                  "Ref": "AWS::Region"
-                }
-              }
-            },
-            "discovery": {
-              "type": "ec2"
-            },
-            "http_auth": false,
-            "index.number_of_shards": 8,
-            "index.number_of_replicas": 2,
-            "index.auto_expand_replicas": "2-all"
-          },
-          "bb_monitor": {
-            "sensu": {
-              "server_url": {
+        }
+    },
+    "Outputs": {
+        "DashboardUrl": {
+            "Value": {
                 "Fn::GetAtt": [
-                  "DashboardELB",
-                  "DNSName"
-                ]
-              },
-            "rabbitmq": {
-                "server": {
-                  "Fn::GetAtt": [
-                    "RabbitMQELB",
+                    "DashboardELB",
                     "DNSName"
-                  ]
-                },
-                "password": {
-                  "Ref": "RabbitMQSensuPassword"
-                }
-              },
-              "pagerduty_api": {
-                "Ref": "PagerDutyAPIKey"
-              }
-            },
-            "logstash": {
-              "rabbitmq_server": {
-                "Fn::GetAtt": [
-                  "RabbitMQELB",
-                  "DNSName"
                 ]
-              },
-              "rabbitmq_password": {
-                "Ref": "RabbitMQLogstashInternalPassword"
-              },
-              "server": {
-                "elasticsearch_server": {
-                  "Fn::GetAtt": [
-                    "ElasticSearchELB",
-                    "DNSName"
-                  ]
-                },
-                "filters": [],
-                "statsd_output": {}
-              }
             }
-          },
-          "rabbitmq": {
-            "cluster": true,
-            "erlang_cookie": {
-                "Ref": "RabbitMQErlangCookie"
+        },
+        "PrivateSubnet": {
+            "Value": {
+                "Ref": "PrivateSubnet"
             }
-          },
-          "rabbitmq_cluster": {
-            "users": [
-              {
-                "user": {
-                  "Ref": "RabbitMQUser"
+        },
+        "PublicSubnet": {
+            "Value": {
+                "Ref": "PublicSubnet"
+            }
+        },
+        "StackId": {
+            "Value": {
+                "Ref": "OpsWorksStack"
+            }
+        },
+        "VPC": {
+            "Description": "VPC",
+            "Value": {
+                "Ref": "VPC"
+            }
+        }
+    },
+    "Parameters": {
+        "BastionInstanceType": {
+            "AllowedValues": [
+                "t2.small",
+                "t2.medium",
+                "m3.medium"
+            ],
+            "Default": "m3.medium",
+            "Description": "Enter t2.small, t2.medium, m3.medium. Default is t2.small.",
+            "Type": "String"
+        },
+        "CookbooksRef": {
+            "Default": "master",
+            "Description": "The git reference to checkout for custom cookbooks",
+            "Type": "String"
+        },
+        "CookbooksRepo": {
+            "Description": "The github url for your custom cookbooks",
+            "Type": "String"
+        },
+        "CookbooksSshKey": {
+            "Default": "",
+            "Description": "The ssh key needed to clone the cookbooks repo",
+            "NoEcho": "true",
+            "Type": "String"
+        },
+        "DashboardInstanceType": {
+            "AllowedValues": [
+                "m3.medium",
+                "m3.large",
+                "c3.large",
+                "r3.large",
+                "m3.2xlarge"
+            ],
+            "Default": "c3.large",
+            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large.",
+            "Type": "String"
+        },
+        "DoormanEnable": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "true",
+            "Description": "Protect all internal resources through Doorman? If you are not deploying this privately through a VPN, this is recommended",
+            "Type": "String"
+        },
+        "DoormanPassword": {
+            "Default": "",
+            "Description": "Password to use for alternate authentication through doorman. Leave empty for none",
+            "Type": "String"
+        },
+        "DoormanSessionSecret": {
+            "Default": "",
+            "Description": "A Secret Salt used to encrypt cookies for doorman",
+            "NoEcho": "true",
+            "Type": "String"
+        },
+        "ElasticSearchInstanceType": {
+            "AllowedValues": [
+                "m3.medium",
+                "m3.large",
+                "c3.large",
+                "r3.large"
+            ],
+            "Default": "r3.large",
+            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is r3.large.",
+            "Type": "String"
+        },
+        "ElasticSearchVolumeSize": {
+            "Default": 1000,
+            "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
+            "MinValue": 20,
+            "Type": "Number"
+        },
+        "GithubOauthAppId": {
+            "Default": "",
+            "Description": "Github Oauth App Id to use for doorman authentication. Leave empty for none.",
+            "Type": "String"
+        },
+        "GithubOauthOrganization": {
+            "Default": "",
+            "Description": "Github Organization to allow through doorman",
+            "Type": "String"
+        },
+        "GithubOauthSecret": {
+            "Default": "",
+            "Description": "Github Oauth App Secret to use for doorman authentication. Leave empty for none.",
+            "NoEcho": "true",
+            "Type": "String"
+        },
+        "GraphiteInstanceType": {
+            "AllowedValues": [
+                "m3.medium",
+                "m3.large",
+                "c3.large",
+                "r3.large"
+            ],
+            "Default": "c3.large",
+            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large.",
+            "Type": "String"
+        },
+        "GraphiteVolumeSize": {
+            "Default": 100,
+            "Description": "Size of disk in GB to use for graphite ebs volumes",
+            "MinValue": 20,
+            "Type": "Number"
+        },
+        "LogstashInstanceType": {
+            "AllowedValues": [
+                "m3.medium",
+                "m3.large",
+                "c3.large",
+                "r3.large"
+            ],
+            "Default": "c3.large",
+            "Description": "Enter m3.medium, m3.large, c3.large, or r3.large. Default is c3.large.",
+            "Type": "String"
+        },
+        "OpsWorksStackColor": {
+            "Default": "rgb(45, 114, 184)",
+            "Description": "RGB Color to use for OpsWorks Stack",
+            "Type": "String"
+        },
+        "PagerDutyAPIKey": {
+            "Default": "",
+            "Description": "The pagerduty api key if you want sensu alerts forwarded to pagerduty",
+            "Type": "String"
+        },
+        "RabbitMQCertificateARN": {
+            "Description": "ARN of hte certificate to use for rabbitmq",
+            "Type": "String"
+        },
+        "RabbitMQErlangCookie": {
+            "Description": "RabbitMQ Erlang Cookie. This should be unique per stack",
+            "NoEcho": "true",
+            "Type": "String"
+        },
+        "RabbitMQInstanceType": {
+            "AllowedValues": [
+                "m3.large",
+                "c3.large",
+                "r3.large"
+            ],
+            "Default": "r3.large",
+            "Description": "Enter m3.large, c3.large, or r3.large. Default is r3.large.",
+            "Type": "String"
+        },
+        "RabbitMQLogstashExternalPassword": {
+            "Description": "RabbitMQ Password",
+            "Type": "String"
+        },
+        "RabbitMQLogstashExternalUser": {
+            "Default": "logstash_external",
+            "Description": "RabbitMQ User",
+            "Type": "String"
+        },
+        "RabbitMQLogstashInternalPassword": {
+            "Description": "RabbitMQ Password",
+            "Type": "String"
+        },
+        "RabbitMQLogstashInternalUser": {
+            "Default": "logstash_internal",
+            "Description": "RabbitMQ User",
+            "Type": "String"
+        },
+        "RabbitMQPassword": {
+            "Default": "hunter2",
+            "Description": "RabbitMQ Password",
+            "Type": "String"
+        },
+        "RabbitMQSensuPassword": {
+            "Description": "RabbitMQ Sensu Password",
+            "Type": "String"
+        },
+        "RabbitMQStatsdPassword": {
+            "Description": "RabbitMQ Statsd Password",
+            "Type": "String"
+        },
+        "RabbitMQUser": {
+            "Default": "logger",
+            "Description": "RabbitMQ User",
+            "Type": "String"
+        },
+        "RabbitMQVolumeSize": {
+            "Default": 20,
+            "Description": "Size of disk in GB to use for elasticsearch ebs volumes",
+            "MinValue": 20,
+            "Type": "Number"
+        },
+        "Route53DomainName": {
+            "Default": "",
+            "Description": "The domain name to append to dns records",
+            "Type": "String"
+        },
+        "Route53ZoneId": {
+            "Default": "",
+            "Description": "The zone id to add dns records to on instance setup. If empty updates won't happen",
+            "Type": "String"
+        },
+        "Version": {
+            "Default": "0.1",
+            "Description": "Just a place holder for version",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "BastionInstance1": {
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "BastionInstanceType"
                 },
-                "password": {
-                  "Ref": "RabbitMQPassword"
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksBastionLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet"
                 }
-              },
-              {
-                "user": {
-                  "Ref": "RabbitMQLogstashExternalUser"
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "DashboardELB": {
+            "Properties": {
+                "HealthCheck": {
+                    "HealthyThreshold": "3",
+                    "Interval": "90",
+                    "Target": "HTTP:80/",
+                    "Timeout": "60",
+                    "UnhealthyThreshold": "5"
                 },
-                "password": {
-                  "Ref": "RabbitMQLogstashExternalPassword"
-                }
-              },
-              {
-                "user": {
-                  "Ref": "RabbitMQLogstashInternalUser"
-                },
-                "password": {
-                  "Ref": "RabbitMQLogstashInternalPassword"
-                }
-              }
-            ]
-          },
-          "kibana": {
-            "version": "3",
-            "kibana3_version": "3.1.1",
-            "elasticsearch_server": {
-              "Fn::GetAtt": [
-                "ElasticSearchELB",
-                "DNSName"
-              ]
-            }
-          },
-          "doorman": {
-            "password": {
-              "Ref": "DoormanEnable"
-            },
-            "session_secret":
-            {
-             "Ref": "DoormanSessionSecret"
-            },
-            "app_id": {
-              "Ref": "GithubOauthAppId"
-            },
-            "app_secret": {
-              "Ref": "GithubOauthSecret"
-            },
-            "org_name": {
-              "Ref": "GithubOauthOrganization"
-            },
-            "password": {
-              "Ref": "DoormanPassword"
-            }
-          },
-          "statsd": {
-            "graphite_host": {
-              "Fn::GetAtt": [
-                "GraphiteELB",
-                "DNSName"
-              ]
-            },
-            "nodejs_bin": "/usr/local/bin/node",
-            "rabbitmq": {
-              "vhost": "/statsd",
-              "user": "statsd",
-              "password": {
-                "Ref": "RabbitMQStatsdPassword"
-              }
-            }
-          }
-        }
-      }
-    },
-    "OpsWorksBastionLayer": {
-      "Type": "AWS::OpsWorks::Layer",
-      "Metadata": {
-        "Comment": "Put the bastion layer inside of opsworks so the same users that have access to opsworks will have access to bastion."
-      },
-      "DependsOn": [
-        "NATIPAddress",
-        "PublicRoute",
-        "PublicSubnetRouteTableAssociation",
-        "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "Name": "Bastion",
-        "Type": "custom",
-        "Shortname": "bastion",
-        "EnableAutoHealing": "true",
-        "AutoAssignElasticIps": "true",
-        "AutoAssignPublicIps": "false",
-        "CustomSecurityGroupIds": [
-          {
-            "Ref": "OpsWorksSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "CustomRecipes": {
-          "Setup": [
-            "bb_monitor::route53",
-            "bb_monitor::logstash_agent"
-          ],
-          "Configure": [
-            "bb_monitor::sensu_client"
-          ],
-          "Deploy": [],
-          "Undeploy": [],
-          "Shutdown": []
-        }
-      }
-    },
-    "BastionInstance1": {
-      "Type": "AWS::OpsWorks::Instance",
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksBastionLayer"
-          }
-        ],
-        "InstanceType": { "Ref":"BastionInstanceType"} ,
-        "SubnetId": {
-          "Ref": "PublicSubnet"
-        }
-      }
-    },
-    "OpsWorksDashboardLayer": {
-      "Type": "AWS::OpsWorks::Layer",
-      "Metadata": {
-        "Comment": ""
-      },
-      "DependsOn": [
-        "NATIPAddress",
-        "PublicRoute",
-        "PublicSubnetRouteTableAssociation",
-        "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "Name": "Dashboard",
-        "Type": "custom",
-        "Shortname": "dashboard",
-        "EnableAutoHealing": "true",
-        "AutoAssignElasticIps": "false",
-        "AutoAssignPublicIps": "false",
-        "CustomSecurityGroupIds": [
-          {
-            "Ref": "OpsWorksSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "CustomRecipes": {
-          "Setup": [
-            "bb_monitor::kibana",
-            "bb_monitor::grafana",
-            "bb_monitor::sensu_server",
-            "bb_monitor::nginx",
-            "bb_monitor::route53",
-            "bb_monitor::logstash_agent"
-          ],
-          "Configure": [
-            "bb_monitor::sensu_client"
-          ],
-          "Deploy": [],
-          "Undeploy": [],
-          "Shutdown": []
-        }
-      }
-    },
-    "DashboardInstance1": {
-      "Type": "AWS::OpsWorks::Instance",
-      "DependsOn": [
-        "RabbitMQInstance1",
-        "GraphiteInstance1"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksDashboardLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "DashboardInstanceType" }
-      }
-    },
-    "OpsWorksGraphiteLayer": {
-      "Type": "AWS::OpsWorks::Layer",
-      "Metadata": {
-        "Comment": ""
-      },
-      "DependsOn": [
-        "NATIPAddress",
-        "PublicRoute",
-        "PublicSubnetRouteTableAssociation",
-        "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "Name": "Graphite",
-        "Type": "custom",
-        "Shortname": "graphite",
-        "EnableAutoHealing": "true",
-        "AutoAssignElasticIps": "false",
-        "AutoAssignPublicIps": "false",
-        "CustomSecurityGroupIds": [
-          {
-            "Ref": "OpsWorksSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "CustomRecipes": {
-          "Setup": [
-            "bb_monitor::graphite",
-            "bb_monitor::route53",
-            "bb_monitor::logstash_agent"
-          ],
-          "Configure": [
-            "bb_monitor::sensu_client"
-          ],
-          "Deploy": [],
-          "Undeploy": [],
-          "Shutdown": [
-            "bb_monitor::sensu_client_remove"
-          ]
-        },
-        "VolumeConfigurations": [
-          {
-            "MountPoint": "/opt/graphite/storage",
-            "NumberOfDisks": 1,
-            "Size": {
-              "Ref": "GraphiteVolumeSize"
-            }
-          }
-        ]
-      }
-    },
-    "GraphiteInstance1": {
-      "Type": "AWS::OpsWorks::Instance",
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksGraphiteLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "GraphiteInstanceType" }
-      }
-    },
-    "OpsWorksElasticSearchLayer": {
-      "Type": "AWS::OpsWorks::Layer",
-      "Metadata": {
-        "Comment": ""
-      },
-      "DependsOn": [
-        "NATIPAddress",
-        "PublicRoute",
-        "PublicSubnetRouteTableAssociation",
-        "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "Name": "ElasticSearch",
-        "Type": "custom",
-        "Shortname": "elasticsearch",
-        "EnableAutoHealing": "true",
-        "AutoAssignElasticIps": "false",
-        "AutoAssignPublicIps": "false",
-        "CustomSecurityGroupIds": [
-          {
-            "Ref": "OpsWorksSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "CustomRecipes": {
-          "Setup": [
-            "bb_elasticsearch",
-            "bb_monitor::route53",
-            "bb_monitor::logstash_agent"
-          ],
-          "Configure": [
-            "bb_monitor::sensu_client"
-          ],
-          "Deploy": [],
-          "Undeploy": [],
-          "Shutdown": [
-            "bb_monitor::sensu_client_remove"
-          ]
-        },
-        "VolumeConfigurations": [
-          {
-            "MountPoint": "/usr/local/var",
-            "NumberOfDisks": 1,
-            "Size": {
-              "Ref": "ElasticSearchVolumeSize"
-            }
-          }
-        ]
-      }
-    },
-    "ElasticSearchInstance1": {
-      "Type": "AWS::OpsWorks::Instance",
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksElasticSearchLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
-      }
-    },
-    "ElasticSearchInstance2": {
-      "Type": "AWS::OpsWorks::Instance",
-      "DependsOn": [
-        "ElasticSearchInstance1"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksElasticSearchLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
-      }
-    },
-    "ElasticSearchInstance3": {
-      "Type": "AWS::OpsWorks::Instance",
-      "DependsOn": [
-        "ElasticSearchInstance2"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksElasticSearchLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
-      }
-    },
-    "OpsWorksRabbitMQLayer": {
-      "Type": "AWS::OpsWorks::Layer",
-      "Metadata": {
-        "Comment": ""
-      },
-      "DependsOn": [
-        "NATIPAddress",
-        "PublicRoute",
-        "PublicSubnetRouteTableAssociation",
-        "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "Name": "RabbitMQ",
-        "Type": "custom",
-        "Shortname": "rabbitmq",
-        "EnableAutoHealing": "true",
-        "AutoAssignElasticIps": "false",
-        "AutoAssignPublicIps": "false",
-        "CustomSecurityGroupIds": [
-          {
-            "Ref": "OpsWorksSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "CustomRecipes": {
-          "Setup": [
-            "rabbitmq_cluster",
-            "bb_monitor::route53",
-            "bb_monitor::logstash_agent"
-          ],
-          "Configure": [
-            "bb_monitor::sensu_client"
-          ],
-          "Deploy": [],
-          "Undeploy": [],
-          "Shutdown": [
-            "bb_monitor::sensu_client_remove"
-          ]
-        },
-        "VolumeConfigurations": [
-          {
-            "MountPoint": "/var/lib/rabbitmq",
-            "NumberOfDisks": 1,
-            "Size": {
-              "Ref": "RabbitMQVolumeSize"
-            }
-          }
-        ]
-      }
-    },
-    "RabbitMQInstance1": {
-      "Type": "AWS::OpsWorks::Instance",
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksRabbitMQLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "RabbitMQInstanceType" }
-      }
-    },
-    "OpsWorksLogstashLayer": {
-      "Type": "AWS::OpsWorks::Layer",
-      "Metadata": {
-        "Comment": ""
-      },
-      "DependsOn": [
-        "NATIPAddress",
-        "PublicRoute",
-        "PublicSubnetRouteTableAssociation",
-        "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "Name": "Logstash",
-        "Type": "custom",
-        "Shortname": "logstash",
-        "EnableAutoHealing": "true",
-        "AutoAssignElasticIps": "false",
-        "AutoAssignPublicIps": "false",
-        "CustomSecurityGroupIds": [
-          {
-            "Ref": "OpsWorksSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "CustomRecipes": {
-          "Setup": [
-            "bb_monitor::route53",
-            "bb_monitor::logstash_server"
-          ],
-          "Configure": [
-            "bb_monitor::sensu_client"
-          ],
-          "Deploy": [],
-          "Undeploy": [],
-          "Shutdown": [
-            "bb_monitor::sensu_client_remove"
-          ]
-        }
-      }
-    },
-    "LogstashInstance1": {
-      "Type": "AWS::OpsWorks::Instance",
-      "DependsOn": [
-        "ElasticSearchInstance1",
-        "ElasticSearchInstance2",
-        "ElasticSearchInstance3",
-        "RabbitMQInstance1"
-      ],
-      "Properties": {
-        "StackId": {
-          "Ref": "OpsWorksStack"
-        },
-        "LayerIds": [
-          {
-            "Ref": "OpsWorksLogstashLayer"
-          }
-        ],
-        "InstanceType": { "Ref" : "LogstashInstanceType" }
-      }
-    },
-    "OpsWorksServiceRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "opsworks.amazonaws.com"
+                "Listeners": [
+                    {
+                        "InstancePort": "80",
+                        "LoadBalancerPort": "80",
+                        "Protocol": "HTTP"
+                    },
+                    {
+                        "InstancePort": "6379",
+                        "LoadBalancerPort": "6379",
+                        "Protocol": "TCP"
+                    },
+                    {
+                        "InstancePort": "4567",
+                        "LoadBalancerPort": "4567",
+                        "Protocol": "TCP"
+                    }
+                ],
+                "SecurityGroups": [
+                    {
+                        "Ref": "DashboardELBSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PublicSubnet"
+                    }
                 ]
-              },
-              "Action": [
-                "sts:AssumeRole"
-              ]
-            }
-          ]
-        },
-        "Path": "/",
-        "Policies": [
-          {
-            "PolicyName": "opsworks-service",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "ec2:*",
-                    "iam:PassRole",
-                    "cloudwatch:GetMetricStatistics",
-                    "elasticloadbalancing:*"
-                  ],
-                  "Resource": "*"
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "OpsWorksInstanceRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "ec2.amazonaws.com"
-                ]
-              },
-              "Action": [
-                "sts:AssumeRole"
-              ]
-            }
-          ]
-        },
-        "Path": "/",
-        "Policies": [
-          {
-            "PolicyName": "opsworks-instance-ec2",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "ec2:CreateSnapshot",
-                    "ec2:CreateTags",
-                    "ec2:DeleteSnapshot",
-                    "ec2:Describe*"
-                  ],
-                  "Resource": [
-                    "*"
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "PolicyName": "opsworks-opsworks",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "opsworks:*",
-                    "ec2:DescribeKeyPairs",
-                    "ec2:DescribeSecurityGroups",
-                    "ec2:DescribeAccountAttributes",
-                    "ec2:DescribeAvailabilityZones",
-                    "ec2:DescribeSecurityGroups",
-                    "ec2:DescribeSubnets",
-                    "ec2:DescribeVpcs",
-                    "elasticloadbalancing:DescribeInstanceHealth",
-                    "elasticloadbalancing:DescribeLoadBalancers",
-                    "iam:GetRolePolicy",
-                    "iam:ListInstanceProfiles",
-                    "iam:ListRoles",
-                    "iam:ListUsers",
-                    "iam:PassRole"
-                  ],
-                  "Resource": "*"
-                }
-              ]
-            }
-          },
-          {
-            "PolicyName": "opsworks-route53",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "route53:*"
-                  ],
-                  "Resource": [
-                    "*"
-                  ]
-                }
-              ]
-            }
-          },
-          {
-            "PolicyName": "opsworks-instance-cloudwatch",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "autoscaling:Describe*",
-                    "cloudwatch:Describe*",
-                    "cloudwatch:Get*",
-                    "cloudwatch:List*",
-                    "logs:Get*",
-                    "logs:Describe*",
-                    "logs:TestMetricFilter",
-                    "sns:Get*",
-                    "sns:List*"
-                  ],
-                  "Effect": "Allow",
-                  "Resource": "*"
-                }
-              ]
-            }
-          },
-          {
-            "PolicyName": "opsworks-instance-elb",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "elasticloadbalancing:DescribeInstanceHealth",
-                    "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                    "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
-                    "elasticloadbalancing:DescribeLoadBalancerPolicies",
-                    "elasticloadbalancing:DescribeLoadBalancers",
-                    "elasticloadbalancing:DescribeTags"
-                  ],
-                  "Resource": [
-                    "*"
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "OpsWorksInstanceProfile": {
-      "Type": "AWS::IAM::InstanceProfile",
-      "Properties": {
-        "Path": "/",
-        "Roles": [
-          {
-            "Ref": "OpsWorksInstanceRole"
-          }
-        ]
-      }
-    },
-    "OpsWorksSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow inbound requests from the ELB to the OpsWorks instances",
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
-            "SourceSecurityGroupId": {
-              "Ref": "DashboardELBSecurityGroup"
-            }
-          }
-        ]
-      }
-    },
-    "DashboardELB": {
-      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-      "Properties": {
-        "SecurityGroups": [
-          {
-            "Ref": "DashboardELBSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "Subnets": [
-          {
-            "Ref": "PublicSubnet"
-          }
-        ],
-        "Listeners": [
-          {
-            "LoadBalancerPort": "80",
-            "InstancePort": "80",
-            "Protocol": "HTTP"
-          },
-          {
-            "LoadBalancerPort": "6379",
-            "InstancePort": "6379",
-            "Protocol": "TCP"
-          },
-          {
-            "LoadBalancerPort": "4567",
-            "InstancePort": "4567",
-            "Protocol": "TCP"
-          }
-        ],
-        "HealthCheck": {
-          "Target": "HTTP:80/",
-          "HealthyThreshold": "3",
-          "UnhealthyThreshold": "5",
-          "Interval": "90",
-          "Timeout": "60"
-        }
-      }
-    },
-    "DashboardELBAttachment": {
-      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
-      "Properties": {
-        "ElasticLoadBalancerName": {
-          "Ref": "DashboardELB"
-        },
-        "LayerId": {
-          "Ref": "OpsWorksDashboardLayer"
-        }
-      }
-    },
-    "DashboardELBSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow inbound access to the ELB",
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ],
-        "SecurityGroupEgress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
-    "RabbitMQELB": {
-      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-      "Properties": {
-        "SecurityGroups": [
-          {
-            "Ref": "RabbitMQELBSecurityGroup"
-          },
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "Subnets": [
-          {
-            "Ref": "PublicSubnet"
-          }
-        ],
-        "Listeners": [
-          {
-            "LoadBalancerPort": "5672",
-            "InstancePort": "5672",
-            "Protocol": "TCP"
-          },
-          {
-            "LoadBalancerPort": "15672",
-            "InstancePort": "15672",
-            "Protocol": "TCP"
-          },
-          {
-            "LoadBalancerPort": "5671",
-            "InstancePort": "5672",
-            "Protocol": "SSL",
-            "SSLCertificateId": {
-              "Ref": "RabbitMQCertificateARN"
-            }
-          }
-        ],
-        "HealthCheck": {
-          "Target": "TCP:5672",
-          "HealthyThreshold": "3",
-          "UnhealthyThreshold": "5",
-          "Interval": "90",
-          "Timeout": "60"
-        }
-      }
-    },
-    "RabbitMQELBAttachment": {
-      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
-      "Properties": {
-        "ElasticLoadBalancerName": {
-          "Ref": "RabbitMQELB"
-        },
-        "LayerId": {
-          "Ref": "OpsWorksRabbitMQLayer"
-        }
-      }
-    },
-    "RabbitMQELBSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow inbound access to the ELB",
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "5671",
-            "ToPort": "5671",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ],
-        "SecurityGroupEgress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "5671",
-            "ToPort": "5671",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
-    "ElasticSearchELB": {
-      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-      "Properties": {
-        "SecurityGroups": [
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "Subnets": [
-          {
-            "Ref": "PrivateSubnet"
-          }
-        ],
-        "Scheme": "internal",
-        "Listeners": [
-          {
-            "LoadBalancerPort": "9200",
-            "InstancePort": "9200",
-            "Protocol": "TCP"
-          },
-          {
-            "LoadBalancerPort": "9300",
-            "InstancePort": "9300",
-            "Protocol": "TCP"
-          }
-        ],
-        "HealthCheck": {
-          "Target": "TCP:9200",
-          "HealthyThreshold": "3",
-          "UnhealthyThreshold": "5",
-          "Interval": "90",
-          "Timeout": "60"
-        }
-      }
-    },
-    "ElasticSearchELBAttachment": {
-      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
-      "Properties": {
-        "ElasticLoadBalancerName": {
-          "Ref": "ElasticSearchELB"
-        },
-        "LayerId": {
-          "Ref": "OpsWorksElasticSearchLayer"
-        }
-      }
-    },
-    "GraphiteELB": {
-      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-      "Properties": {
-        "SecurityGroups": [
-          {
-            "Ref": "InternalSecurityGroup"
-          }
-        ],
-        "Subnets": [
-          {
-            "Ref": "PrivateSubnet"
-          }
-        ],
-        "Scheme": "internal",
-        "Listeners": [
-          {
-            "LoadBalancerPort": "8081",
-            "InstancePort": "8081",
-            "Protocol": "TCP"
-          },
-          {
-            "LoadBalancerPort": "2003",
-            "InstancePort": "2003",
-            "Protocol": "TCP"
-          }
-        ],
-        "HealthCheck": {
-          "Target": "TCP:2003",
-          "HealthyThreshold": "3",
-          "UnhealthyThreshold": "5",
-          "Interval": "90",
-          "Timeout": "60"
-        }
-      }
-    },
-    "GraphiteELBAttachment": {
-      "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment",
-      "Properties": {
-        "ElasticLoadBalancerName": {
-          "Ref": "GraphiteELB"
-        },
-        "LayerId": {
-          "Ref": "OpsWorksGraphiteLayer"
-        }
-      }
-    },
-    "InternalSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow VPC access to ports running on dashboard server",
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": {
-              "Fn::FindInMap": [
-                "SubnetConfig",
-                "VPC",
-                "CIDR"
-              ]
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "SourceSecurityGroupId": {
-              "Ref": "DashboardELBSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": {
-              "Fn::Join": [
-                "",
-                [
-                  {
-                    "Ref": "NATIPAddress"
-                  },
-                  "/32"
-                ]
-              ]
-            }
-          }
-        ],
-        "SecurityGroupEgress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
-    "VPC": {
-      "Type": "AWS::EC2::VPC",
-      "DependsOn": "OpsWorksServiceRole",
-      "Properties": {
-        "CidrBlock": {
-          "Fn::FindInMap": [
-            "SubnetConfig",
-            "VPC",
-            "CIDR"
-          ]
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Public"
-          }
-        ]
-      }
-    },
-    "PublicSubnet": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "AvailabilityZone": {
-          "Fn::Select": [
-            "0",
-            {
-              "Fn::GetAZs": {
-                "Ref": "AWS::Region"
-              }
-            }
-          ]
-        },
-        "CidrBlock": {
-          "Fn::FindInMap": [
-            "SubnetConfig",
-            "Public",
-            "CIDR"
-          ]
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Public"
-          }
-        ]
-      }
-    },
-    "InternetGateway": {
-      "Type": "AWS::EC2::InternetGateway",
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Public"
-          }
-        ]
-      }
-    },
-    "VPCGatewayAttachment": {
-      "Type": "AWS::EC2::VPCGatewayAttachment",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "InternetGatewayId": {
-          "Ref": "InternetGateway"
-        }
-      }
-    },
-    "PublicRouteTable": {
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Public"
-          }
-        ]
-      }
-    },
-    "PublicRoute": {
-      "Type": "AWS::EC2::Route",
-      "DependsOn": "VPCGatewayAttachment",
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "PublicRouteTable"
-        },
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": {
-          "Ref": "InternetGateway"
-        }
-      }
-    },
-    "PublicSubnetRouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "PublicSubnet"
-        },
-        "RouteTableId": {
-          "Ref": "PublicRouteTable"
-        }
-      }
-    },
-    "PublicNetworkAcl": {
-      "Type": "AWS::EC2::NetworkAcl",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Public"
-          }
-        ]
-      }
-    },
-    "InboundHTTPPublicNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PublicNetworkAcl"
-        },
-        "RuleNumber": "100",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "80",
-          "To": "80"
-        }
-      }
-    },
-    "InboundHTTPSPublicNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PublicNetworkAcl"
-        },
-        "RuleNumber": "101",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "443",
-          "To": "443"
-        }
-      }
-    },
-    "InboundSSHPublicNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PublicNetworkAcl"
-        },
-        "RuleNumber": "102",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "22",
-          "To": "22"
-        }
-      }
-    },
-    "InboundEmphemeralPublicNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PublicNetworkAcl"
-        },
-        "RuleNumber": "103",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "1024",
-          "To": "65535"
-        }
-      }
-    },
-    "OutboundPublicNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PublicNetworkAcl"
-        },
-        "RuleNumber": "100",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "true",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "0",
-          "To": "65535"
-        }
-      }
-    },
-    "PublicSubnetNetworkAclAssociation": {
-      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "PublicSubnet"
-        },
-        "NetworkAclId": {
-          "Ref": "PublicNetworkAcl"
-        }
-      }
-    },
-    "PrivateSubnet": {
-      "Type": "AWS::EC2::Subnet",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "AvailabilityZone": {
-          "Fn::Select": [
-            "0",
-            {
-              "Fn::GetAZs": {
-                "Ref": "AWS::Region"
-              }
-            }
-          ]
-        },
-        "CidrBlock": {
-          "Fn::FindInMap": [
-            "SubnetConfig",
-            "Private",
-            "CIDR"
-          ]
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Name",
-            "Value": "Private"
-          }
-        ]
-      }
-    },
-    "PrivateRouteTable": {
-      "Type": "AWS::EC2::RouteTable",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Private"
-          }
-        ]
-      }
-    },
-    "PrivateSubnetRouteTableAssociation": {
-      "Type": "AWS::EC2::SubnetRouteTableAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "PrivateSubnet"
-        },
-        "RouteTableId": {
-          "Ref": "PrivateRouteTable"
-        }
-      }
-    },
-    "PrivateRoute": {
-      "Type": "AWS::EC2::Route",
-      "Properties": {
-        "RouteTableId": {
-          "Ref": "PrivateRouteTable"
-        },
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "InstanceId": {
-          "Ref": "NATDevice"
-        }
-      }
-    },
-    "PrivateNetworkAcl": {
-      "Type": "AWS::EC2::NetworkAcl",
-      "Properties": {
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "Tags": [
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackName"
-            }
-          },
-          {
-            "Key": "Network",
-            "Value": "Private"
-          }
-        ]
-      }
-    },
-    "InboundPrivateNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PrivateNetworkAcl"
-        },
-        "RuleNumber": "100",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "false",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "0",
-          "To": "65535"
-        }
-      }
-    },
-    "OutBoundPrivateNetworkAclEntry": {
-      "Type": "AWS::EC2::NetworkAclEntry",
-      "Properties": {
-        "NetworkAclId": {
-          "Ref": "PrivateNetworkAcl"
-        },
-        "RuleNumber": "100",
-        "Protocol": "6",
-        "RuleAction": "allow",
-        "Egress": "true",
-        "CidrBlock": "0.0.0.0/0",
-        "PortRange": {
-          "From": "0",
-          "To": "65535"
-        }
-      }
-    },
-    "PrivateSubnetNetworkAclAssociation": {
-      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
-      "Properties": {
-        "SubnetId": {
-          "Ref": "PrivateSubnet"
-        },
-        "NetworkAclId": {
-          "Ref": "PrivateNetworkAcl"
-        }
-      }
-    },
-    "NATIPAddress": {
-      "Type": "AWS::EC2::EIP",
-      "Properties": {
-        "Domain": "vpc",
-        "InstanceId": {
-          "Ref": "NATDevice"
-        }
-      }
-    },
-    "NATDevice": {
-      "Type": "AWS::EC2::Instance",
-      "Properties": {
-        "InstanceType": "m1.small",
-        "SubnetId": {
-          "Ref": "PublicSubnet"
-        },
-        "SourceDestCheck": "false",
-        "ImageId": {
-          "Fn::FindInMap": [
-            "AWSNATAMI",
-            {
-              "Ref": "AWS::Region"
             },
-            "AMI"
-          ]
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
         },
-        "SecurityGroupIds": [
-          {
-            "Ref": "NATSecurityGroup"
-          }
-        ]
-      }
-    },
-    "NATSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow OpsWorks instances to access the NAT Device",
-        "VpcId": {
-          "Ref": "VPC"
+        "DashboardELBAttachment": {
+            "Properties": {
+                "ElasticLoadBalancerName": {
+                    "Ref": "DashboardELB"
+                },
+                "LayerId": {
+                    "Ref": "OpsWorksDashboardLayer"
+                }
+            },
+            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
         },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
-            "SourceSecurityGroupId": {
-              "Ref": "OpsWorksSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "9418",
-            "ToPort": "9418",
-            "SourceSecurityGroupId": {
-              "Ref": "OpsWorksSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "443",
-            "ToPort": "443",
-            "SourceSecurityGroupId": {
-              "Ref": "OpsWorksSecurityGroup"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": {
-              "Fn::FindInMap": [
-                "SubnetConfig",
-                "VPC",
-                "CIDR"
-              ]
-            }
-          }
-        ],
-        "SecurityGroupEgress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "0",
-            "ToPort": "65535",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
+        "DashboardELBSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow inbound access to the ELB",
+                "SecurityGroupEgress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "ToPort": "80"
+                    }
+                ],
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "ToPort": "80"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "DashboardInstance1": {
+            "DependsOn": [
+                "RabbitMQInstance1",
+                "GraphiteInstance1"
+            ],
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "DashboardInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksDashboardLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "ElasticSearchELB": {
+            "Properties": {
+                "HealthCheck": {
+                    "HealthyThreshold": "3",
+                    "Interval": "90",
+                    "Target": "TCP:9200",
+                    "Timeout": "60",
+                    "UnhealthyThreshold": "5"
+                },
+                "Listeners": [
+                    {
+                        "InstancePort": "9200",
+                        "LoadBalancerPort": "9200",
+                        "Protocol": "TCP"
+                    },
+                    {
+                        "InstancePort": "9300",
+                        "LoadBalancerPort": "9300",
+                        "Protocol": "TCP"
+                    }
+                ],
+                "Scheme": "internal",
+                "SecurityGroups": [
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PrivateSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "ElasticSearchELBAttachment": {
+            "Properties": {
+                "ElasticLoadBalancerName": {
+                    "Ref": "ElasticSearchELB"
+                },
+                "LayerId": {
+                    "Ref": "OpsWorksElasticSearchLayer"
+                }
+            },
+            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+        },
+        "ElasticSearchInstance1": {
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "ElasticSearchInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksElasticSearchLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "ElasticSearchInstance2": {
+            "DependsOn": [
+                "ElasticSearchInstance1"
+            ],
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "ElasticSearchInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksElasticSearchLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "ElasticSearchInstance3": {
+            "DependsOn": [
+                "ElasticSearchInstance2"
+            ],
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "ElasticSearchInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksElasticSearchLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "GraphiteELB": {
+            "Properties": {
+                "HealthCheck": {
+                    "HealthyThreshold": "3",
+                    "Interval": "90",
+                    "Target": "TCP:2003",
+                    "Timeout": "60",
+                    "UnhealthyThreshold": "5"
+                },
+                "Listeners": [
+                    {
+                        "InstancePort": "8081",
+                        "LoadBalancerPort": "8081",
+                        "Protocol": "TCP"
+                    },
+                    {
+                        "InstancePort": "2003",
+                        "LoadBalancerPort": "2003",
+                        "Protocol": "TCP"
+                    }
+                ],
+                "Scheme": "internal",
+                "SecurityGroups": [
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PrivateSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "GraphiteELBAttachment": {
+            "Properties": {
+                "ElasticLoadBalancerName": {
+                    "Ref": "GraphiteELB"
+                },
+                "LayerId": {
+                    "Ref": "OpsWorksGraphiteLayer"
+                }
+            },
+            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+        },
+        "GraphiteInstance1": {
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "GraphiteInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksGraphiteLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "InboundEmphemeralPublicNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "false",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "1024",
+                    "To": "65535"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "103"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "InboundHTTPPublicNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "false",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "80",
+                    "To": "80"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "100"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "InboundHTTPSPublicNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "false",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "443",
+                    "To": "443"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "101"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "InboundPrivateNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "false",
+                "NetworkAclId": {
+                    "Ref": "PrivateNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "0",
+                    "To": "65535"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "100"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "InboundSSHPublicNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "false",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "22",
+                    "To": "22"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "102"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "InternalSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow VPC access to ports running on dashboard server",
+                "SecurityGroupEgress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "ToPort": "65535"
+                    }
+                ],
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": {
+                            "Fn::FindInMap": [
+                                "SubnetConfig",
+                                "VPC",
+                                "CIDR"
+                            ]
+                        },
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "ToPort": "65535"
+                    },
+                    {
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "DashboardELBSecurityGroup"
+                        },
+                        "ToPort": "65535"
+                    },
+                    {
+                        "CidrIp": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    {
+                                        "Ref": "NATIPAddress"
+                                    },
+                                    "/32"
+                                ]
+                            ]
+                        },
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "ToPort": "65535"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "InternetGateway": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Public"
+                    }
+                ]
+            },
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "LogstashInstance1": {
+            "DependsOn": [
+                "ElasticSearchInstance1",
+                "ElasticSearchInstance2",
+                "ElasticSearchInstance3",
+                "RabbitMQInstance1"
+            ],
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "LogstashInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksLogstashLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "NATDevice": {
+            "Properties": {
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "AWSNATAMI",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "AMI"
+                    ]
+                },
+                "InstanceType": "m1.small",
+                "SecurityGroupIds": [
+                    {
+                        "Ref": "NATSecurityGroup"
+                    }
+                ],
+                "SourceDestCheck": "false",
+                "SubnetId": {
+                    "Ref": "PublicSubnet"
+                }
+            },
+            "Type": "AWS::EC2::Instance"
+        },
+        "NATIPAddress": {
+            "Properties": {
+                "Domain": "vpc",
+                "InstanceId": {
+                    "Ref": "NATDevice"
+                }
+            },
+            "Type": "AWS::EC2::EIP"
+        },
+        "NATSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow OpsWorks instances to access the NAT Device",
+                "SecurityGroupEgress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "ToPort": "65535"
+                    }
+                ],
+                "SecurityGroupIngress": [
+                    {
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "OpsWorksSecurityGroup"
+                        },
+                        "ToPort": "80"
+                    },
+                    {
+                        "FromPort": "9418",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "OpsWorksSecurityGroup"
+                        },
+                        "ToPort": "9418"
+                    },
+                    {
+                        "FromPort": "443",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "OpsWorksSecurityGroup"
+                        },
+                        "ToPort": "443"
+                    },
+                    {
+                        "CidrIp": {
+                            "Fn::FindInMap": [
+                                "SubnetConfig",
+                                "VPC",
+                                "CIDR"
+                            ]
+                        },
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "ToPort": "65535"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "OpsWorksBastionLayer": {
+            "DependsOn": [
+                "NATIPAddress",
+                "PublicRoute",
+                "PublicSubnetRouteTableAssociation",
+                "PrivateRoute",
+                "PrivateSubnetRouteTableAssociation"
+            ],
+            "Metadata": {
+                "Comment": "Put the bastion layer inside of opsworks so the same users that have access to opsworks will have access to bastion."
+            },
+            "Properties": {
+                "AutoAssignElasticIps": "true",
+                "AutoAssignPublicIps": "false",
+                "CustomRecipes": {
+                    "Configure": [
+                        "bb_monitor::sensu_client"
+                    ],
+                    "Deploy": [],
+                    "Setup": [
+                        "bb_monitor::route53",
+                        "bb_monitor::logstash_agent"
+                    ],
+                    "Shutdown": [],
+                    "Undeploy": []
+                },
+                "CustomSecurityGroupIds": [
+                    {
+                        "Ref": "OpsWorksSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "EnableAutoHealing": "true",
+                "Name": "Bastion",
+                "Shortname": "bastion",
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "Type": "custom"
+            },
+            "Type": "AWS::OpsWorks::Layer"
+        },
+        "OpsWorksDashboardLayer": {
+            "DependsOn": [
+                "NATIPAddress",
+                "PublicRoute",
+                "PublicSubnetRouteTableAssociation",
+                "PrivateRoute",
+                "PrivateSubnetRouteTableAssociation"
+            ],
+            "Metadata": {
+                "Comment": ""
+            },
+            "Properties": {
+                "AutoAssignElasticIps": "false",
+                "AutoAssignPublicIps": "false",
+                "CustomRecipes": {
+                    "Configure": [
+                        "bb_monitor::sensu_client"
+                    ],
+                    "Deploy": [],
+                    "Setup": [
+                        "bb_monitor::kibana",
+                        "bb_monitor::grafana",
+                        "bb_monitor::sensu_server",
+                        "bb_monitor::nginx",
+                        "bb_monitor::route53",
+                        "bb_monitor::logstash_agent"
+                    ],
+                    "Shutdown": [],
+                    "Undeploy": []
+                },
+                "CustomSecurityGroupIds": [
+                    {
+                        "Ref": "OpsWorksSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "EnableAutoHealing": "true",
+                "Name": "Dashboard",
+                "Shortname": "dashboard",
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "Type": "custom"
+            },
+            "Type": "AWS::OpsWorks::Layer"
+        },
+        "OpsWorksElasticSearchLayer": {
+            "DependsOn": [
+                "NATIPAddress",
+                "PublicRoute",
+                "PublicSubnetRouteTableAssociation",
+                "PrivateRoute",
+                "PrivateSubnetRouteTableAssociation"
+            ],
+            "Metadata": {
+                "Comment": ""
+            },
+            "Properties": {
+                "AutoAssignElasticIps": "false",
+                "AutoAssignPublicIps": "false",
+                "CustomRecipes": {
+                    "Configure": [
+                        "bb_monitor::sensu_client"
+                    ],
+                    "Deploy": [],
+                    "Setup": [
+                        "bb_elasticsearch",
+                        "bb_monitor::route53",
+                        "bb_monitor::logstash_agent"
+                    ],
+                    "Shutdown": [
+                        "bb_monitor::sensu_client_remove"
+                    ],
+                    "Undeploy": []
+                },
+                "CustomSecurityGroupIds": [
+                    {
+                        "Ref": "OpsWorksSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "EnableAutoHealing": "true",
+                "Name": "ElasticSearch",
+                "Shortname": "elasticsearch",
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "Type": "custom",
+                "VolumeConfigurations": [
+                    {
+                        "MountPoint": "/usr/local/var",
+                        "NumberOfDisks": 1,
+                        "Size": {
+                            "Ref": "ElasticSearchVolumeSize"
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::OpsWorks::Layer"
+        },
+        "OpsWorksGraphiteLayer": {
+            "DependsOn": [
+                "NATIPAddress",
+                "PublicRoute",
+                "PublicSubnetRouteTableAssociation",
+                "PrivateRoute",
+                "PrivateSubnetRouteTableAssociation"
+            ],
+            "Metadata": {
+                "Comment": ""
+            },
+            "Properties": {
+                "AutoAssignElasticIps": "false",
+                "AutoAssignPublicIps": "false",
+                "CustomRecipes": {
+                    "Configure": [
+                        "bb_monitor::sensu_client"
+                    ],
+                    "Deploy": [],
+                    "Setup": [
+                        "bb_monitor::graphite",
+                        "bb_monitor::route53",
+                        "bb_monitor::logstash_agent"
+                    ],
+                    "Shutdown": [
+                        "bb_monitor::sensu_client_remove"
+                    ],
+                    "Undeploy": []
+                },
+                "CustomSecurityGroupIds": [
+                    {
+                        "Ref": "OpsWorksSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "EnableAutoHealing": "true",
+                "Name": "Graphite",
+                "Shortname": "graphite",
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "Type": "custom",
+                "VolumeConfigurations": [
+                    {
+                        "MountPoint": "/opt/graphite/storage",
+                        "NumberOfDisks": 1,
+                        "Size": {
+                            "Ref": "GraphiteVolumeSize"
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::OpsWorks::Layer"
+        },
+        "OpsWorksInstanceProfile": {
+            "Properties": {
+                "Path": "/",
+                "Roles": [
+                    {
+                        "Ref": "OpsWorksInstanceRole"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::InstanceProfile"
+        },
+        "OpsWorksInstanceRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "ec2:CreateSnapshot",
+                                        "ec2:CreateTags",
+                                        "ec2:DeleteSnapshot",
+                                        "ec2:Describe*"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        },
+                        "PolicyName": "opsworks-instance-ec2"
+                    },
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "opsworks:*",
+                                        "ec2:DescribeKeyPairs",
+                                        "ec2:DescribeSecurityGroups",
+                                        "ec2:DescribeAccountAttributes",
+                                        "ec2:DescribeAvailabilityZones",
+                                        "ec2:DescribeSecurityGroups",
+                                        "ec2:DescribeSubnets",
+                                        "ec2:DescribeVpcs",
+                                        "elasticloadbalancing:DescribeInstanceHealth",
+                                        "elasticloadbalancing:DescribeLoadBalancers",
+                                        "iam:GetRolePolicy",
+                                        "iam:ListInstanceProfiles",
+                                        "iam:ListRoles",
+                                        "iam:ListUsers",
+                                        "iam:PassRole"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "*"
+                                }
+                            ]
+                        },
+                        "PolicyName": "opsworks-opsworks"
+                    },
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "route53:*"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        },
+                        "PolicyName": "opsworks-route53"
+                    },
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "autoscaling:Describe*",
+                                        "cloudwatch:Describe*",
+                                        "cloudwatch:Get*",
+                                        "cloudwatch:List*",
+                                        "logs:Get*",
+                                        "logs:Describe*",
+                                        "logs:TestMetricFilter",
+                                        "sns:Get*",
+                                        "sns:List*"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "*"
+                                }
+                            ]
+                        },
+                        "PolicyName": "opsworks-instance-cloudwatch"
+                    },
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "elasticloadbalancing:DescribeInstanceHealth",
+                                        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                                        "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
+                                        "elasticloadbalancing:DescribeLoadBalancerPolicies",
+                                        "elasticloadbalancing:DescribeLoadBalancers",
+                                        "elasticloadbalancing:DescribeTags"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        },
+                        "PolicyName": "opsworks-instance-elb"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "OpsWorksLogstashLayer": {
+            "DependsOn": [
+                "NATIPAddress",
+                "PublicRoute",
+                "PublicSubnetRouteTableAssociation",
+                "PrivateRoute",
+                "PrivateSubnetRouteTableAssociation"
+            ],
+            "Metadata": {
+                "Comment": ""
+            },
+            "Properties": {
+                "AutoAssignElasticIps": "false",
+                "AutoAssignPublicIps": "false",
+                "CustomRecipes": {
+                    "Configure": [
+                        "bb_monitor::sensu_client"
+                    ],
+                    "Deploy": [],
+                    "Setup": [
+                        "bb_monitor::route53",
+                        "bb_monitor::logstash_server"
+                    ],
+                    "Shutdown": [
+                        "bb_monitor::sensu_client_remove"
+                    ],
+                    "Undeploy": []
+                },
+                "CustomSecurityGroupIds": [
+                    {
+                        "Ref": "OpsWorksSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "EnableAutoHealing": "true",
+                "Name": "Logstash",
+                "Shortname": "logstash",
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "Type": "custom"
+            },
+            "Type": "AWS::OpsWorks::Layer"
+        },
+        "OpsWorksRabbitMQLayer": {
+            "DependsOn": [
+                "NATIPAddress",
+                "PublicRoute",
+                "PublicSubnetRouteTableAssociation",
+                "PrivateRoute",
+                "PrivateSubnetRouteTableAssociation"
+            ],
+            "Metadata": {
+                "Comment": ""
+            },
+            "Properties": {
+                "AutoAssignElasticIps": "false",
+                "AutoAssignPublicIps": "false",
+                "CustomRecipes": {
+                    "Configure": [
+                        "bb_monitor::sensu_client"
+                    ],
+                    "Deploy": [],
+                    "Setup": [
+                        "rabbitmq_cluster",
+                        "bb_monitor::route53",
+                        "bb_monitor::logstash_agent"
+                    ],
+                    "Shutdown": [
+                        "bb_monitor::sensu_client_remove"
+                    ],
+                    "Undeploy": []
+                },
+                "CustomSecurityGroupIds": [
+                    {
+                        "Ref": "OpsWorksSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "EnableAutoHealing": "true",
+                "Name": "RabbitMQ",
+                "Shortname": "rabbitmq",
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                },
+                "Type": "custom",
+                "VolumeConfigurations": [
+                    {
+                        "MountPoint": "/var/lib/rabbitmq",
+                        "NumberOfDisks": 1,
+                        "Size": {
+                            "Ref": "RabbitMQVolumeSize"
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::OpsWorks::Layer"
+        },
+        "OpsWorksSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow inbound requests from the ELB to the OpsWorks instances",
+                "SecurityGroupIngress": [
+                    {
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "SourceSecurityGroupId": {
+                            "Ref": "DashboardELBSecurityGroup"
+                        },
+                        "ToPort": "80"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "OpsWorksServiceRole": {
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "opsworks.amazonaws.com"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "ec2:*",
+                                        "iam:PassRole",
+                                        "cloudwatch:GetMetricStatistics",
+                                        "elasticloadbalancing:*"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "*"
+                                }
+                            ]
+                        },
+                        "PolicyName": "opsworks-service"
+                    }
+                ]
+            },
+            "Type": "AWS::IAM::Role"
+        },
+        "OpsWorksStack": {
+            "Properties": {
+                "Attributes": {
+                    "Color": {
+                        "Ref": "OpsWorksStackColor"
+                    }
+                },
+                "ChefConfiguration": {
+                    "BerkshelfVersion": "3.1.3",
+                    "ManageBerkshelf": true
+                },
+                "ConfigurationManager": {
+                    "Name": "Chef",
+                    "Version": "11.10"
+                },
+                "CustomCookbooksSource": {
+                    "Revision": {
+                        "Ref": "CookbooksRef"
+                    },
+                    "SshKey": {
+                        "Ref": "CookbooksSshKey"
+                    },
+                    "Type": "git",
+                    "Url": {
+                        "Ref": "CookbooksRepo"
+                    }
+                },
+                "CustomJson": {
+                    "aws_region": {
+                        "Ref": "AWS::Region"
+                    },
+                    "bb_monitor": {
+                        "logstash": {
+                            "rabbitmq": {
+                                "password": {
+                                    "Ref": "RabbitMQLogstashInternalPassword"
+                                },
+                                "server": {
+                                    "Fn::GetAtt": [
+                                        "RabbitMQELB",
+                                        "DNSName"
+                                    ]
+                                }
+                            },
+                            "server": {
+                                "elasticsearch_server": {
+                                    "Fn::GetAtt": [
+                                        "ElasticSearchELB",
+                                        "DNSName"
+                                    ]
+                                },
+                                "filters": [],
+                                "statsd_output": {}
+                            }
+                        },
+                        "sensu": {
+                            "pagerduty_api": {
+                                "Ref": "PagerDutyAPIKey"
+                            },
+                            "rabbitmq": {
+                                "password": {
+                                    "Ref": "RabbitMQSensuPassword"
+                                },
+                                "server": {
+                                    "Fn::GetAtt": [
+                                        "RabbitMQELB",
+                                        "DNSName"
+                                    ]
+                                }
+                            },
+                            "server_url": {
+                                "Fn::GetAtt": [
+                                    "DashboardELB",
+                                    "DNSName"
+                                ]
+                            }
+                        }
+                    },
+                    "chef_environment": "production",
+                    "doorman": {
+                        "app_id": {
+                            "Ref": "GithubOauthAppId"
+                        },
+                        "app_secret": {
+                            "Ref": "GithubOauthSecret"
+                        },
+                        "org_name": {
+                            "Ref": "GithubOauthOrganization"
+                        },
+                        "password": {
+                            "Ref": "DoormanPassword"
+                        },
+                        "session_secret": {
+                            "Ref": "DoormanSessionSecret"
+                        }
+                    },
+                    "elasticsearch": {
+                        "cloud": {
+                            "aws": {
+                                "region": {
+                                    "Ref": "AWS::Region"
+                                }
+                            }
+                        },
+                        "cluster": {
+                            "name": "logstash"
+                        },
+                        "discovery": {
+                            "type": "ec2"
+                        },
+                        "http_auth": false,
+                        "index.auto_expand_replicas": "2-all",
+                        "index.number_of_replicas": 2,
+                        "index.number_of_shards": 8,
+                        "plugins": {
+                            "elasticsearch/elasticsearch-cloud-aws": {
+                                "version": "2.2.0"
+                            }
+                        },
+                        "version": "1.0.1"
+                    },
+                    "graphite": {
+                        "host": {
+                            "Fn::GetAtt": [
+                                "GraphiteELB",
+                                "DNSName"
+                            ]
+                        }
+                    },
+                    "kibana": {
+                        "elasticsearch_server": {
+                            "Fn::GetAtt": [
+                                "ElasticSearchELB",
+                                "DNSName"
+                            ]
+                        },
+                        "kibana3_version": "3.1.1",
+                        "version": "3"
+                    },
+                    "rabbitmq": {
+                        "cluster": true,
+                        "erlang_cookie": {
+                            "Ref": "RabbitMQErlangCookie"
+                        }
+                    },
+                    "rabbitmq_cluster": {
+                        "users": [
+                            {
+                                "password": {
+                                    "Ref": "RabbitMQPassword"
+                                },
+                                "user": {
+                                    "Ref": "RabbitMQUser"
+                                }
+                            },
+                            {
+                                "password": {
+                                    "Ref": "RabbitMQLogstashExternalPassword"
+                                },
+                                "user": {
+                                    "Ref": "RabbitMQLogstashExternalUser"
+                                }
+                            },
+                            {
+                                "password": {
+                                    "Ref": "RabbitMQLogstashInternalPassword"
+                                },
+                                "user": {
+                                    "Ref": "RabbitMQLogstashInternalUser"
+                                }
+                            }
+                        ]
+                    },
+                    "route53": {
+                        "domain_name": {
+                            "Ref": "Route53DomainName"
+                        },
+                        "zone_id": {
+                            "Ref": "Route53ZoneId"
+                        }
+                    },
+                    "statsd": {
+                        "graphite_host": {
+                            "Fn::GetAtt": [
+                                "GraphiteELB",
+                                "DNSName"
+                            ]
+                        },
+                        "nodejs_bin": "/usr/local/bin/node",
+                        "rabbitmq": {
+                            "password": {
+                                "Ref": "RabbitMQStatsdPassword"
+                            },
+                            "user": "statsd",
+                            "vhost": "/statsd"
+                        }
+                    }
+                },
+                "DefaultInstanceProfileArn": {
+                    "Fn::GetAtt": [
+                        "OpsWorksInstanceProfile",
+                        "Arn"
+                    ]
+                },
+                "DefaultOs": "Ubuntu 14.04 LTS",
+                "DefaultSubnetId": {
+                    "Ref": "PrivateSubnet"
+                },
+                "Name": {
+                    "Ref": "AWS::StackName"
+                },
+                "ServiceRoleArn": {
+                    "Fn::GetAtt": [
+                        "OpsWorksServiceRole",
+                        "Arn"
+                    ]
+                },
+                "UseCustomCookbooks": true,
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::OpsWorks::Stack"
+        },
+        "OutBoundPrivateNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "true",
+                "NetworkAclId": {
+                    "Ref": "PrivateNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "0",
+                    "To": "65535"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "100"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "OutboundPublicNetworkAclEntry": {
+            "Properties": {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": "true",
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "PortRange": {
+                    "From": "0",
+                    "To": "65535"
+                },
+                "Protocol": "6",
+                "RuleAction": "allow",
+                "RuleNumber": "100"
+            },
+            "Type": "AWS::EC2::NetworkAclEntry"
+        },
+        "PrivateNetworkAcl": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Private"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::NetworkAcl"
+        },
+        "PrivateRoute": {
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "InstanceId": {
+                    "Ref": "NATDevice"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "PrivateRouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Private"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "PrivateSubnet": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Fn::FindInMap": [
+                        "SubnetConfig",
+                        "Private",
+                        "CIDR"
+                    ]
+                },
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "Private"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PrivateSubnetNetworkAclAssociation": {
+            "Properties": {
+                "NetworkAclId": {
+                    "Ref": "PrivateNetworkAcl"
+                },
+                "SubnetId": {
+                    "Ref": "PrivateSubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetNetworkAclAssociation"
+        },
+        "PrivateSubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PrivateSubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "PublicNetworkAcl": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Public"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::NetworkAcl"
+        },
+        "PublicRoute": {
+            "DependsOn": "VPCGatewayAttachment",
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                }
+            },
+            "Type": "AWS::EC2::Route"
+        },
+        "PublicRouteTable": {
+            "Properties": {
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Public"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::RouteTable"
+        },
+        "PublicSubnet": {
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Fn::FindInMap": [
+                        "SubnetConfig",
+                        "Public",
+                        "CIDR"
+                    ]
+                },
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Public"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::Subnet"
+        },
+        "PublicSubnetNetworkAclAssociation": {
+            "Properties": {
+                "NetworkAclId": {
+                    "Ref": "PublicNetworkAcl"
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetNetworkAclAssociation"
+        },
+        "PublicSubnetRouteTableAssociation": {
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet"
+                }
+            },
+            "Type": "AWS::EC2::SubnetRouteTableAssociation"
+        },
+        "RabbitMQELB": {
+            "Properties": {
+                "HealthCheck": {
+                    "HealthyThreshold": "3",
+                    "Interval": "90",
+                    "Target": "TCP:5672",
+                    "Timeout": "60",
+                    "UnhealthyThreshold": "5"
+                },
+                "Listeners": [
+                    {
+                        "InstancePort": "5672",
+                        "LoadBalancerPort": "5672",
+                        "Protocol": "TCP"
+                    },
+                    {
+                        "InstancePort": "15672",
+                        "LoadBalancerPort": "15672",
+                        "Protocol": "TCP"
+                    },
+                    {
+                        "InstancePort": "5672",
+                        "LoadBalancerPort": "5671",
+                        "Protocol": "SSL",
+                        "SSLCertificateId": {
+                            "Ref": "RabbitMQCertificateARN"
+                        }
+                    }
+                ],
+                "SecurityGroups": [
+                    {
+                        "Ref": "RabbitMQELBSecurityGroup"
+                    },
+                    {
+                        "Ref": "InternalSecurityGroup"
+                    }
+                ],
+                "Subnets": [
+                    {
+                        "Ref": "PublicSubnet"
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "RabbitMQELBAttachment": {
+            "Properties": {
+                "ElasticLoadBalancerName": {
+                    "Ref": "RabbitMQELB"
+                },
+                "LayerId": {
+                    "Ref": "OpsWorksRabbitMQLayer"
+                }
+            },
+            "Type": "AWS::OpsWorks::ElasticLoadBalancerAttachment"
+        },
+        "RabbitMQELBSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Allow inbound access to the ELB",
+                "SecurityGroupEgress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "5671",
+                        "IpProtocol": "tcp",
+                        "ToPort": "5671"
+                    }
+                ],
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "5671",
+                        "IpProtocol": "tcp",
+                        "ToPort": "5671"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "RabbitMQInstance1": {
+            "Properties": {
+                "InstanceType": {
+                    "Ref": "RabbitMQInstanceType"
+                },
+                "LayerIds": [
+                    {
+                        "Ref": "OpsWorksRabbitMQLayer"
+                    }
+                ],
+                "StackId": {
+                    "Ref": "OpsWorksStack"
+                }
+            },
+            "Type": "AWS::OpsWorks::Instance"
+        },
+        "VPC": {
+            "DependsOn": "OpsWorksServiceRole",
+            "Properties": {
+                "CidrBlock": {
+                    "Fn::FindInMap": [
+                        "SubnetConfig",
+                        "VPC",
+                        "CIDR"
+                    ]
+                },
+                "Tags": [
+                    {
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Public"
+                    }
+                ]
+            },
+            "Type": "AWS::EC2::VPC"
+        },
+        "VPCGatewayAttachment": {
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::VPCGatewayAttachment"
+        }
     }
-  },
-  "Outputs": {
-    "StackId": {
-      "Value": {
-        "Ref": "OpsWorksStack"
-      }
-    },
-    "VPC": {
-      "Description": "VPC",
-      "Value": {
-        "Ref": "VPC"
-      }
-    },
-    "PublicSubnet": {
-      "Value": {
-        "Ref": "PublicSubnet"
-      }
-    },
-    "PrivateSubnet": {
-      "Value": {
-        "Ref": "PrivateSubnet"
-      }
-    },
-    "DashboardUrl": {
-      "Value": {
-        "Fn::GetAtt": [
-          "DashboardELB",
-          "DNSName"
-        ]
-      }
-    }
-  }
 }

--- a/create_stack
+++ b/create_stack
@@ -68,8 +68,15 @@ class OpsVizStackCreator(object):
             raise SystemExit("Failed to get ARN from cert upload. Resp: {}".format(resp))
 
     def prepare_cert(self):
-        self.ssl_key, self.ssl_cert = self.gen_certificate()
-        self.cert_arn = self.upload_cert()
+        certs_response = self.iam.list_server_certs()
+        cert_list = certs_response[u'list_server_certificates_response'][u'list_server_certificates_result'][u'server_certificate_metadata_list']
+        print(cert_list)
+        valid_certs =[x for x in cert_list if x[u'server_certificate_name'] == "{}_cert".format(self.opts.stack_name)]
+        if len(valid_certs) == 1:
+            self.cert_arn = valid_certs[0][u'arn']
+        else:
+            self.ssl_key, self.ssl_cert = self.gen_certificate()
+            self.cert_arn = self.upload_cert()
 
         return self.cert_arn
 

--- a/site-cookbooks/bb_monitor/recipes/nginx.rb
+++ b/site-cookbooks/bb_monitor/recipes/nginx.rb
@@ -1,6 +1,13 @@
 include_recipe 'nginx'
-doorman_enabled = node["doorman"]["enabled"].equal? "true"
-include_recipe 'bb_monitor::doorman' if doorman_enabled
+
+begin
+  doorman_enabled = node["doorman"]["enabled"].eql? "true"
+  Chef::Log.debug("node[\"doorman\"][\"enabled\"] is #{node['doorman']['enabled']}.  Configuring doorman.")
+  Chef::Log.info("doorman_enabled is #{doorman_enabled}.  Configuring doorman.")
+  include_recipe 'bb_monitor::doorman' if doorman_enabled
+rescue
+  Chef::Log.info("Couldn't find node[\"doorman\"][\"enabled\"].  Not configuring doorman.")
+end
 
 file "/etc/nginx/sites-enabled/default" do
   action :delete

--- a/site-cookbooks/bb_monitor/recipes/sensu_checks.rb
+++ b/site-cookbooks/bb_monitor/recipes/sensu_checks.rb
@@ -76,7 +76,7 @@ end
 include_recipe "sensu"
 
 sensu_check "rabbitmq-messages" do
-  command "check-rabbitmq-messages.rb --user sensu_monitor --password #{node["sensu"]["rabbitmq"]["password"]} -w 600 -c 900"
+  command "check-rabbitmq-messages.rb --user sensu_monitor --password \"#{node["sensu"]["rabbitmq"]["password"]}\" -w 600 -c 900"
   handlers node[:bb_monitor][:sensu][:default_check_handlers]
   subscribers ["rabbitmq"]
   interval 60

--- a/site-cookbooks/bb_monitor/recipes/sensu_checks.rb
+++ b/site-cookbooks/bb_monitor/recipes/sensu_checks.rb
@@ -84,7 +84,7 @@ sensu_check "rabbitmq-messages" do
 end
 
 sensu_check "rabbitmq-cluster-health" do
-  command "rabbitmq-cluster-health.rb --user sensu_monitor --password #{node["sensu"]["rabbitmq"]["password"]}"
+  command "rabbitmq-cluster-health.rb --user sensu_monitor --password \"#{node["sensu"]["rabbitmq"]["password"]}\""
   handlers node[:bb_monitor][:sensu][:default_check_handlers]
   subscribers ["rabbitmq"]
   interval 60
@@ -92,7 +92,7 @@ end
 
 sensu_check "rabbitmq-overview" do
   type "metric"
-  command "rabbitmq-overview-metrics.rb --user sensu_monitor --password #{node["sensu"]["rabbitmq"]["password"]} --scheme stats.:::name:::"
+  command "rabbitmq-overview-metrics.rb --user sensu_monitor --password \"#{node["sensu"]["rabbitmq"]["password"]}\" --scheme stats.:::name:::"
   handlers node[:bb_monitor][:sensu][:default_metric_handlers]
   subscribers ["rabbitmq"]
   interval 60


### PR DESCRIPTION
fixes issue #33 and makes dashboard1 a prerequisite for logstash; the client has to create the rabbitmq exchange before the server can use it.

Fixes a broken piece of Dashboard config

Fixes some password escaping for the sensu checks