### PR TITLE
Adds dependencies for clients subscribing to mysql

### DIFF
--- a/site-cookbooks/bb_external/README.md
+++ b/site-cookbooks/bb_external/README.md
@@ -12,7 +12,7 @@ Wrapper recipes for installing logstash and sensu clients on machines that are e
 |[:bb_external][:sensu][:rabbitmq][:user]|String|The rabbitmq user to use|sensu
 |[:bb_external][:sensu][:mysql][:user]|String|The mysql user to use|sensu
 |[:bb_external][:sensu][:mysql][:password]|String|The mysql password to use|**required if subscriptions include 'mysql'**
-|[:bb_external][:sensu][:subscriptions]|Array|The subscriptions the client belongs to |[]
+|[:bb_external][:sensu][:subscriptions]|Array|The subscriptions the client belongs to |['all']
 |[:bb_external][:logstash][:root]|Boolean|Whether or not to run logstash as root|false
 |[:bb_external][:logstash][:rabbitmq][:host]|String|The public facing rabbitmq endpoint|**required**
 |[:bb_external][:logstash][:rabbitmq][:password]|String|The password for rabbitmq's logstash user|**required**

--- a/site-cookbooks/bb_external/README.md
+++ b/site-cookbooks/bb_external/README.md
@@ -10,6 +10,8 @@ Wrapper recipes for installing logstash and sensu clients on machines that are e
 |[:bb_external][:sensu][:rabbitmq][:server]|String|The public facing rabbitmq endpoint|**required**
 |[:bb_external][:sensu][:rabbitmq][:password]|String|The password for rabbitmq's sensu user|**required**
 |[:bb_external][:sensu][:rabbitmq][:user]|String|The rabbitmq user to use|sensu
+|[:bb_external][:sensu][:mysql][:user]|String|The mysql user to use|sensu
+|[:bb_external][:sensu][:mysql][:password]|String|The mysql password to use|**required if subscriptions include 'mysql'**
 |[:bb_external][:sensu][:subscriptions]|Array|The subscriptions the client belongs to |[]
 |[:bb_external][:logstash][:root]|Boolean|Whether or not to run logstash as root|false
 |[:bb_external][:logstash][:rabbitmq][:host]|String|The public facing rabbitmq endpoint|**required**

--- a/site-cookbooks/bb_external/README.md
+++ b/site-cookbooks/bb_external/README.md
@@ -10,9 +10,9 @@ Wrapper recipes for installing logstash and sensu clients on machines that are e
 |[:bb_external][:sensu][:rabbitmq][:server]|String|The public facing rabbitmq endpoint|**required**
 |[:bb_external][:sensu][:rabbitmq][:password]|String|The password for rabbitmq's sensu user|**required**
 |[:bb_external][:sensu][:rabbitmq][:user]|String|The rabbitmq user to use|sensu
+|[:bb_external][:sensu][:subscriptions]|Array|The subscriptions the client belongs to |['all']
 |[:bb_external][:sensu][:mysql][:user]|String|The mysql user to use|sensu
 |[:bb_external][:sensu][:mysql][:password]|String|The mysql password to use|**required if subscriptions include 'mysql'**
-|[:bb_external][:sensu][:subscriptions]|Array|The subscriptions the client belongs to |['all']
 |[:bb_external][:logstash][:root]|Boolean|Whether or not to run logstash as root|false
 |[:bb_external][:logstash][:rabbitmq][:host]|String|The public facing rabbitmq endpoint|**required**
 |[:bb_external][:logstash][:rabbitmq][:password]|String|The password for rabbitmq's logstash user|**required**

--- a/site-cookbooks/bb_external/attributes/default.rb
+++ b/site-cookbooks/bb_external/attributes/default.rb
@@ -8,6 +8,9 @@ default[:bb_external][:sensu][:rabbitmq][:user] = "sensu"
 default[:bb_external][:sensu][:rabbitmq][:ssl] = true
 default[:bb_external][:sensu][:rabbitmq][:port] = 5671
 
+# Default setting for mysql user for sensu plugins
+default[:bb_external][:sensu][:mysql][:user] = "sensu"
+
 default[:bb_external][:logstash][:rabbitmq][:port] = 5671
 default[:bb_external][:logstash][:rabbitmq][:ssl] = true
 default[:bb_external][:logstash][:rabbitmq][:verify_ssl] = false

--- a/site-cookbooks/bb_external/files/default/sensu_plugins/mysql-graphite.rb
+++ b/site-cookbooks/bb_external/files/default/sensu_plugins/mysql-graphite.rb
@@ -68,48 +68,48 @@ require 'inifile'
 
 class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
   option :host,
-         short: '-h HOST',
-         long: '--host HOST',
-         description: 'Mysql Host to connect to',
-         required: true
+         :short => '-h HOST',
+         :long => '--host HOST',
+         :description => 'Mysql Host to connect to',
+         :default => "localhost"
 
   option :port,
-         short: '-P PORT',
-         long: '--port PORT',
-         description: 'Mysql Port to connect to',
-         proc: proc(&:to_i),
-         default: 3306
+         :short => '-P PORT',
+         :long => '--port PORT',
+         :description => 'Mysql Port to connect to',
+         :proc => proc(&:to_i),
+         :default => 3306
 
   option :username,
-         short: '-u USERNAME',
-         long: '--user USERNAME',
-         description: 'Mysql Username'
+         :short => '-u USERNAME',
+         :long => '--user USERNAME',
+         :description => 'Mysql Username'
 
   option :password,
-         short: '-p PASSWORD',
-         long: '--pass PASSWORD',
-         description: 'Mysql password',
-         default: ''
+         :short => '-p PASSWORD',
+         :long => '--pass PASSWORD',
+         :description => 'Mysql password',
+         :default => ''
 
   option :ini,
-         short: '-i',
-         long: '--ini VALUE',
-         description: 'My.cnf ini file'
+         :short => '-i',
+         :long => '--ini VALUE',
+         :description => 'My.cnf ini file'
 
   option :scheme,
-         description: 'Metric naming scheme, text to prepend to metric',
-         short: '-s SCHEME',
-         long: '--scheme SCHEME',
-         default: "#{Socket.gethostname}.mysql"
+         :description => 'Metric naming scheme, text to prepend to metric',
+         :short => '-s SCHEME',
+         :long => '--scheme SCHEME',
+         :default => "#{Socket.gethostname}.mysql"
 
   option :socket,
-         short: '-S SOCKET',
-         long: '--socket SOCKET'
+         :short => '-S SOCKET',
+         :long => '--socket SOCKET'
 
   option :verbose,
-         short: '-v',
-         long: '--verbose',
-         boolean: true
+         :short => '-v',
+         :long => '--verbose',
+         :boolean => true
 
   def run
     # props to https://github.com/coredump/hoardd/blob/master/scripts-available/mysql.coffee
@@ -236,11 +236,11 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
       end
       begin
         mysql = Mysql2::Client.new(
-          host: mysql_host,
-          port: config[:port],
-          username: db_user,
-          password: db_pass,
-          socket: config[:socket]
+          :host => mysql_host,
+          :port => config[:port],
+          :username => db_user,
+          :password => db_pass,
+          :socket => config[:socket]
         )
 
         results = mysql.query('SHOW GLOBAL STATUS')

--- a/site-cookbooks/bb_external/recipes/sensu_client.rb
+++ b/site-cookbooks/bb_external/recipes/sensu_client.rb
@@ -54,6 +54,3 @@ unless platform_family?("windows")
 end
 
 include_recipe "sensu::client_service"
-
-# Add mysql dependencies if check is subscribing to 'mysql' in [:bb_external][:sensu][:subscriptions]
-include_recipe "bb_external::sensu_mysql" if node[:bb_external][:sensu][:subscriptions].include? 'mysql'

--- a/site-cookbooks/bb_external/recipes/sensu_client.rb
+++ b/site-cookbooks/bb_external/recipes/sensu_client.rb
@@ -54,3 +54,6 @@ unless platform_family?("windows")
 end
 
 include_recipe "sensu::client_service"
+
+# Add mysql dependencies if check is subscribing to 'mysql' in [:bb_external][:sensu][:subscriptions]
+include_recipe "bb_external::sensu_mysql" if node[:bb_external][:sensu][:subscriptions].include? 'mysql'

--- a/site-cookbooks/bb_external/recipes/sensu_mysql.rb
+++ b/site-cookbooks/bb_external/recipes/sensu_mysql.rb
@@ -1,0 +1,30 @@
+# Add gem dependences for mysql plugins
+%w[
+  mysql2
+  inifile
+].each do |package|
+  gem_package package do
+    action :install
+  end
+end
+
+log "MySQL sensu plugins" do
+  level :info
+  message "MySQL plugin execution"
+end
+
+%w(password).each do |attribute|
+  unless node[:bb_external][:sensu][:mysql].has_key?(attribute)
+    raise "Missing attribute bb_external.sensu.mysql.#{attribute}"
+  end
+end
+
+# configure /opt/sensu/.my.cnf
+# TODO: If using 5.6 we can
+template "/opt/sensu/.my.cnf" do
+  source "my.cnf_sensu.erb"
+  owner "sensu"
+  group "sensu"
+  mode "0400"
+  variables( :mysql_user => node[:bb_external][:sensu][:mysql][:user], :mysql_password => node[:bb_external][:sensu][:mysql][:password] )
+end

--- a/site-cookbooks/bb_external/recipes/sensu_mysql.rb
+++ b/site-cookbooks/bb_external/recipes/sensu_mysql.rb
@@ -20,7 +20,7 @@ end
 end
 
 # configure /opt/sensu/.my.cnf
-# TODO: If using 5.6 we can
+# TODO: If using 5.6 we can utilize encrypted files, but plugins will have to be modified
 template "/opt/sensu/.my.cnf" do
   source "my.cnf_sensu.erb"
   owner "sensu"

--- a/site-cookbooks/bb_external/recipes/sensu_mysql.rb
+++ b/site-cookbooks/bb_external/recipes/sensu_mysql.rb
@@ -1,10 +1,12 @@
 # Add gem dependences for mysql plugins
-%w[
-  mysql2
-  inifile
-].each do |package|
+# Versions are added because CentOS can't run latest version of
+{
+  "mysql2" => {:version=>"0.3.18"},
+  "inifile" => {:version=>"2.0.2"}
+}.each do |package, attributes|
   gem_package package do
     action :install
+    version attributes[:version]
   end
 end
 

--- a/site-cookbooks/bb_external/recipes/sensu_plugins.rb
+++ b/site-cookbooks/bb_external/recipes/sensu_plugins.rb
@@ -47,3 +47,7 @@ end
 gem_package 'aws-sdk' do
   action :install
 end
+
+# Add mysql dependencies if check is subscribing to 'mysql' in [:bb_external][:sensu][:subscriptions]
+include_recipe "bb_external::sensu_mysql" if node[:bb_external][:sensu][:subscriptions].include? 'mysql'
+

--- a/site-cookbooks/bb_external/templates/default/my.cnf_sensu.erb
+++ b/site-cookbooks/bb_external/templates/default/my.cnf_sensu.erb
@@ -1,0 +1,3 @@
+[client]
+user=<%= @mysql_user %>
+password=<%= @mysql_password %>


### PR DESCRIPTION
This adds the 'mysql2' and 'inifile' dependencies, in addition to a /opt/sensu/.my.cnf file to avoid passing user/password in plaintext.

I don't create the sensu user here, as this requires access to a privileged user, which is outside the scope of the client installation.