### PR TITLE
downgrading rabbitmq in berksfile.lock to 3.3.0

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -132,7 +132,7 @@ GRAPH
   python (1.4.6)
     build-essential (>= 0.0.0)
     yum-epel (>= 0.0.0)
-  rabbitmq (3.11.0)
+  rabbitmq (3.3.0)
     erlang (>= 0.9)
     yum-epel (>= 0.0.0)
     yum-erlang_solutions (>= 0.0.0)


### PR DESCRIPTION
There's a conflict with rabbitMQ cookbooks > 3.3.0 and opsworks due to being locked in with Chef <= 11.10. 

https://github.com/jjasghar/rabbitmq/issues/191