### PR TITLE
Feature/multi az

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -213,8 +213,17 @@
       "Public": {
         "CIDR": "10.133.0.0/24"
       },
-      "Private": {
+      "Private0": {
         "CIDR": "10.133.1.0/24"
+      },
+      "Private1": {
+        "CIDR": "10.133.2.0/24"
+      },
+      "Private2": {
+        "CIDR": "10.133.3.0/24"
+      },
+      "Private3": {
+        "CIDR": "10.133.4.0/24"
       }
     }
   },
@@ -268,7 +277,7 @@
           "Ref": "VPC"
         },
         "DefaultSubnetId": {
-          "Ref": "PrivateSubnet"
+          "Ref": "PrivateSubnet0"
         },
         "CustomJson": {
           "chef_environment": "production",
@@ -460,7 +469,10 @@
         "PublicRoute",
         "PublicSubnetRouteTableAssociation",
         "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
+        "PrivateSubnet0RouteTableAssociation",
+        "PrivateSubnet1RouteTableAssociation",
+        "PrivateSubnet2RouteTableAssociation",
+        "PrivateSubnet3RouteTableAssociation"
       ],
       "Properties": {
         "StackId": {
@@ -521,7 +533,10 @@
         "PublicRoute",
         "PublicSubnetRouteTableAssociation",
         "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation",
+        "PrivateSubnet0RouteTableAssociation",
+        "PrivateSubnet1RouteTableAssociation",
+        "PrivateSubnet2RouteTableAssociation",
+        "PrivateSubnet3RouteTableAssociation",
         "RedisCluster"
       ],
       "Properties": {
@@ -589,7 +604,10 @@
         "PublicRoute",
         "PublicSubnetRouteTableAssociation",
         "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
+        "PrivateSubnet0RouteTableAssociation",
+        "PrivateSubnet1RouteTableAssociation",
+        "PrivateSubnet2RouteTableAssociation",
+        "PrivateSubnet3RouteTableAssociation"
       ],
       "Properties": {
         "StackId": {
@@ -659,7 +677,10 @@
         "PublicRoute",
         "PublicSubnetRouteTableAssociation",
         "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
+        "PrivateSubnet0RouteTableAssociation",
+        "PrivateSubnet1RouteTableAssociation",
+        "PrivateSubnet2RouteTableAssociation",
+        "PrivateSubnet3RouteTableAssociation"
       ],
       "Properties": {
         "StackId": {
@@ -716,7 +737,8 @@
             "Ref": "OpsWorksElasticSearchLayer"
           }
         ],
-        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
+        "InstanceType": { "Ref" : "ElasticSearchInstanceType" },
+        "SubnetId": { "Ref" : "PrivateSubnet0" }
       }
     },
     "ElasticSearchInstance2": {
@@ -733,7 +755,8 @@
             "Ref": "OpsWorksElasticSearchLayer"
           }
         ],
-        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
+        "InstanceType": { "Ref" : "ElasticSearchInstanceType" },
+        "SubnetId": { "Ref" : "PrivateSubnet1" }
       }
     },
     "ElasticSearchInstance3": {
@@ -750,7 +773,8 @@
             "Ref": "OpsWorksElasticSearchLayer"
           }
         ],
-        "InstanceType": { "Ref" : "ElasticSearchInstanceType" }
+        "InstanceType": { "Ref" : "ElasticSearchInstanceType" },
+        "SubnetId": { "Ref" : "PrivateSubnet2" }
       }
     },
     "OpsWorksRabbitMQLayer": {
@@ -763,7 +787,10 @@
         "PublicRoute",
         "PublicSubnetRouteTableAssociation",
         "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
+        "PrivateSubnet0RouteTableAssociation",
+        "PrivateSubnet1RouteTableAssociation",
+        "PrivateSubnet2RouteTableAssociation",
+        "PrivateSubnet3RouteTableAssociation"
       ],
       "Properties": {
         "StackId": {
@@ -833,7 +860,10 @@
         "PublicRoute",
         "PublicSubnetRouteTableAssociation",
         "PrivateRoute",
-        "PrivateSubnetRouteTableAssociation"
+        "PrivateSubnet0RouteTableAssociation",
+        "PrivateSubnet1RouteTableAssociation",
+        "PrivateSubnet2RouteTableAssociation",
+        "PrivateSubnet3RouteTableAssociation"
       ],
       "Properties": {
         "StackId": {
@@ -1269,9 +1299,7 @@
           }
         ],
         "Subnets": [
-          {
-            "Ref": "PrivateSubnet"
-          }
+          { "Ref": "PrivateSubnet0" }, { "Ref": "PrivateSubnet1" }, { "Ref": "PrivateSubnet2" }, { "Ref": "PrivateSubnet3" }
         ],
         "Scheme": "internal",
         "Listeners": [
@@ -1315,9 +1343,7 @@
           }
         ],
         "Subnets": [
-          {
-            "Ref": "PrivateSubnet"
-          }
+          { "Ref": "PrivateSubnet0" }, { "Ref": "PrivateSubnet1" }, { "Ref": "PrivateSubnet2" }, { "Ref": "PrivateSubnet3" }
         ],
         "Scheme": "internal",
         "Listeners": [
@@ -1421,7 +1447,7 @@
       "Type": "AWS::ElastiCache::SubnetGroup",
       "Properties": {
         "Description": "Subnet Group for redis",
-        "SubnetIds": [ {"Ref": "PrivateSubnet" } ]
+        "SubnetIds": [ { "Ref": "PrivateSubnet0" }, { "Ref": "PrivateSubnet1" }, { "Ref": "PrivateSubnet2" }, { "Ref": "PrivateSubnet3" } ]
       }
     },
     "RedisSecurityGroup": {
@@ -1702,7 +1728,7 @@
         }
       }
     },
-    "PrivateSubnet": {
+    "PrivateSubnet0": {
       "Type": "AWS::EC2::Subnet",
       "Properties": {
         "VpcId": {
@@ -1721,7 +1747,7 @@
         "CidrBlock": {
           "Fn::FindInMap": [
             "SubnetConfig",
-            "Private",
+            "Private0",
             "CIDR"
           ]
         },
@@ -1734,7 +1760,118 @@
           },
           {
             "Key": "Name",
-            "Value": "Private"
+            "Value": "opsviz-Private0"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet1": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::GetAZs": {
+                "Ref": "AWS::Region"
+              }
+            }
+          ]
+        },
+        "CidrBlock": {
+          "Fn::FindInMap": [
+            "SubnetConfig",
+            "Private1",
+            "CIDR"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Name",
+            "Value": "opsviz-Private1"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet2": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "2",
+            {
+              "Fn::GetAZs": {
+                "Ref": "AWS::Region"
+              }
+            }
+          ]
+        },
+        "CidrBlock": {
+          "Fn::FindInMap": [
+            "SubnetConfig",
+            "Private2",
+            "CIDR"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Name",
+            "Value": "opsviz-Private2"
+          }
+        ]
+      }
+    },
+    "PrivateSubnet3": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "VpcId": {
+          "Ref": "VPC"
+        },
+        "AvailabilityZone": {
+          "Fn::Select": [
+            "3",
+            {
+              "Fn::GetAZs": {
+                "Ref": "AWS::Region"
+              }
+            }
+          ]
+        },
+        "CidrBlock": {
+          "Fn::FindInMap": [
+            "SubnetConfig",
+            "Private3",
+            "CIDR"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "Application",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          {
+            "Key": "Name",
+            "Value": "opsviz-Private3"
           }
         ]
       }
@@ -1759,11 +1896,44 @@
         ]
       }
     },
-    "PrivateSubnetRouteTableAssociation": {
+    "PrivateSubnet0RouteTableAssociation": {
       "Type": "AWS::EC2::SubnetRouteTableAssociation",
       "Properties": {
         "SubnetId": {
-          "Ref": "PrivateSubnet"
+          "Ref": "PrivateSubnet0"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet1RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet1"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet2RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet2"
+        },
+        "RouteTableId": {
+          "Ref": "PrivateRouteTable"
+        }
+      }
+    },
+    "PrivateSubnet3RouteTableAssociation": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet3"
         },
         "RouteTableId": {
           "Ref": "PrivateRouteTable"
@@ -1836,11 +2006,44 @@
         }
       }
     },
-    "PrivateSubnetNetworkAclAssociation": {
+    "PrivateSubnet0NetworkAclAssociation": {
       "Type": "AWS::EC2::SubnetNetworkAclAssociation",
       "Properties": {
         "SubnetId": {
-          "Ref": "PrivateSubnet"
+          "Ref": "PrivateSubnet0"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet1NetworkAclAssociation": {
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet1"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet2NetworkAclAssociation": {
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet2"
+        },
+        "NetworkAclId": {
+          "Ref": "PrivateNetworkAcl"
+        }
+      }
+    },
+    "PrivateSubnet3NetworkAclAssociation": {
+      "Type": "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "PrivateSubnet3"
         },
         "NetworkAclId": {
           "Ref": "PrivateNetworkAcl"
@@ -1953,9 +2156,24 @@
         "Ref": "PublicSubnet"
       }
     },
-    "PrivateSubnet": {
+    "PrivateSubnet0": {
       "Value": {
-        "Ref": "PrivateSubnet"
+        "Ref": "PrivateSubnet0"
+      }
+    },
+    "PrivateSubnet1": {
+      "Value": {
+        "Ref": "PrivateSubnet1"
+      }
+    },
+    "PrivateSubnet2": {
+      "Value": {
+        "Ref": "PrivateSubnet2"
+      }
+    },
+    "PrivateSubnet3": {
+      "Value": {
+        "Ref": "PrivateSubnet3"
       }
     },
     "DashboardUrl": {

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ It also builds everything with private-only ip addresses and restricts all exter
 ### Setup
 1. Upload an SSL Certificate to AWS for the RabbitMQ ELB - and note the generated ARN [Instructions](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ssl-server-cert.html#upload-cert)
 2. Create a new CloudFormation stack on the [CloudFormation Dashboard](https://console.aws.amazon.com/cloudformation/home) [image](screenshots/create_stack.png)
-3. Choose "Upload a template to Amazon S3" on upload cloudformation.json
+3. Choose "Upload a template to Amazon S3" on upload cloudformation.json (the template is larger than 51000 bytes, so it needs to be uploaded to S3)
 4. See Cloudformation Paramaters section on specifics for paramaters [image](screenshots/cloudformation_parameters.png)
 5. *During options I recommend disabling rollback on failture so you can see logs on OpsWorks boxes when recipes fail* [image](screenshots/rollback_on_failure.png)
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ It also builds everything with private-only ip addresses and restricts all exter
 - CloudFormation Script
 - VPC
   - ELBs
-  - Public/Private subnets
+  - 1 Public and 4 Private subnets
 - OpsWorks
   - Bastion
   - Sensu server
@@ -89,7 +89,7 @@ All of these will need to be filled in, for secure passwords and a secure erlang
     - graphite.opsvis.example.com => Graphite ELB <Internal Only>
 
 ### External Access
-*All instances other than the NAT and Bastion hosts are within the private subnet and cannot be accessed directly*
+*All instances other than the NAT and Bastion hosts are within the private subnets and cannot be accessed directly*
 
 RabbitMQ has a public facing ELB in front of it with SSL termination.
 The dashboard instance has an ELB in front of it so the dasbhoards for grafana, kibana, graphite, and sensu are publicly accessible (Authentication is still required)


### PR DESCRIPTION
This is not the most elegant, but it creates 4 private subnets in different AZ to be used by the stack. It begins to address https://github.com/pythian/opsviz/issues/51.

Private ELBs are configured to use these private subnets. The initial elasticsearch instances are spanned across these as well.

This will be used to further implement auto-scaling features for several of the components.

Warnings:
1)The cloudformation.json file will be larger than 51000 bytes, thus requiring it to be stored in S3 to launch the stack.
2)Some properties have been renamed so this is likely to break any cfn "update-stack" features. 
